### PR TITLE
upgrade ReactMapGL but not MapLibre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "react-dev-utils": "^12.0.0",
         "react-dom": "^17.0.2",
         "react-leaflet": "^3.2.5",
-        "react-map-gl": "^6.1.19",
+        "react-map-gl": "^7.0.6",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^5.0.0",
@@ -2785,20 +2785,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@math.gl/web-mercator": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.5.7.tgz",
-      "integrity": "sha512-i0w6AcV2b5+yeUQOA/KdnnzTYMUZvEKzHbbxI+ZyCuFs3p9S/IUt/EWVw4KGGOjVbf3UrGFlWSM70Th+0KyrsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "gl-matrix": "~3.3.0"
-      }
-    },
-    "node_modules/@math.gl/web-mercator/node_modules/gl-matrix": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
-      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7993,14 +7979,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -11233,19 +11211,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
-    "node_modules/mjolnir.js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.6.0.tgz",
-      "integrity": "sha512-rGA7+BJKvXI0ypxQD/+rQE/sW26kmc8UIZWhmQrjhwCf/zvhbcBlsu2vPB6w0Kv/rVnVFEONTSQqC0vFEpQvIA==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "hammerjs": "^2.0.8"
-      },
-      "engines": {
-        "node": ">= 4",
-        "npm": ">= 3"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -13350,65 +13315,15 @@
       }
     },
     "node_modules/react-map-gl": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.19.tgz",
-      "integrity": "sha512-rrDoRyEIGzVLUB5QfgsZ5xCw7jeUtmmYzHUv86xDx8oGp90VTV2KTQJ4RPQiSAmpfIFh6/pPqI28Pguf1u/mOg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.0.6.tgz",
+      "integrity": "sha512-c6HcIJ/qhiK/ifxGH2WtgHZAAa5PePUvCL/O3juMCdcUOuvujN3rjK2Cg+Yei9Mp/fDN6z15/g3St9PKQGBG7A==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@types/geojson": "^7946.0.7",
-        "@types/mapbox-gl": "^2.0.3",
-        "mapbox-gl": "^2.3.0",
-        "mjolnir.js": "^2.5.0",
-        "prop-types": "^15.7.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "viewport-mercator-project": "^7.0.4"
-      },
-      "engines": {
-        "node": ">= 4",
-        "npm": ">= 3"
+        "@types/mapbox-gl": "^2.6.0"
       },
       "peerDependencies": {
+        "mapbox-gl": "*",
         "react": ">=16.3.0"
-      }
-    },
-    "node_modules/react-map-gl/node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-      "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
-    },
-    "node_modules/react-map-gl/node_modules/@mapbox/tiny-sdf": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-      "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
-    },
-    "node_modules/react-map-gl/node_modules/mapbox-gl": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.7.0.tgz",
-      "integrity": "sha512-7sNoQIpizMjoQkFIcxpWzFCcMd8GJFN0Po00oFZGm1X7xS5XMrzwu+ClfO/ehZqKLa9IS7E3Pj0e2PT+9KeqaA==",
-      "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.1",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^2.0.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.2",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.3",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.3.0",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.4",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.3"
       }
     },
     "node_modules/react-refresh": {
@@ -13617,11 +13532,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -15192,14 +15102,6 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/viewport-mercator-project": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
-      "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
-      "dependencies": {
-        "@math.gl/web-mercator": "^3.5.5"
       }
     },
     "node_modules/vt-pbf": {
@@ -18042,22 +17944,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
-    },
-    "@math.gl/web-mercator": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.5.7.tgz",
-      "integrity": "sha512-i0w6AcV2b5+yeUQOA/KdnnzTYMUZvEKzHbbxI+ZyCuFs3p9S/IUt/EWVw4KGGOjVbf3UrGFlWSM70Th+0KyrsA==",
-      "requires": {
-        "@babel/runtime": "^7.12.0",
-        "gl-matrix": "~3.3.0"
-      },
-      "dependencies": {
-        "gl-matrix": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
-          "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA=="
-        }
-      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -21846,11 +21732,6 @@
         "duplexer": "^0.1.2"
       }
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -24183,15 +24064,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
-    "mjolnir.js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.6.0.tgz",
-      "integrity": "sha512-rGA7+BJKvXI0ypxQD/+rQE/sW26kmc8UIZWhmQrjhwCf/zvhbcBlsu2vPB6w0Kv/rVnVFEONTSQqC0vFEpQvIA==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "hammerjs": "^2.0.8"
-      }
-    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -25594,60 +25466,11 @@
       }
     },
     "react-map-gl": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-6.1.19.tgz",
-      "integrity": "sha512-rrDoRyEIGzVLUB5QfgsZ5xCw7jeUtmmYzHUv86xDx8oGp90VTV2KTQJ4RPQiSAmpfIFh6/pPqI28Pguf1u/mOg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.0.6.tgz",
+      "integrity": "sha512-c6HcIJ/qhiK/ifxGH2WtgHZAAa5PePUvCL/O3juMCdcUOuvujN3rjK2Cg+Yei9Mp/fDN6z15/g3St9PKQGBG7A==",
       "requires": {
-        "@babel/runtime": "^7.0.0",
-        "@types/geojson": "^7946.0.7",
-        "@types/mapbox-gl": "^2.0.3",
-        "mapbox-gl": "^2.3.0",
-        "mjolnir.js": "^2.5.0",
-        "prop-types": "^15.7.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "viewport-mercator-project": "^7.0.4"
-      },
-      "dependencies": {
-        "@mapbox/mapbox-gl-supported": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-          "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
-        },
-        "@mapbox/tiny-sdf": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-          "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
-        },
-        "mapbox-gl": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.7.0.tgz",
-          "integrity": "sha512-7sNoQIpizMjoQkFIcxpWzFCcMd8GJFN0Po00oFZGm1X7xS5XMrzwu+ClfO/ehZqKLa9IS7E3Pj0e2PT+9KeqaA==",
-          "requires": {
-            "@mapbox/geojson-rewind": "^0.5.1",
-            "@mapbox/geojson-types": "^1.0.2",
-            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-            "@mapbox/mapbox-gl-supported": "^2.0.0",
-            "@mapbox/point-geometry": "^0.1.0",
-            "@mapbox/tiny-sdf": "^2.0.2",
-            "@mapbox/unitbezier": "^0.0.0",
-            "@mapbox/vector-tile": "^1.3.1",
-            "@mapbox/whoots-js": "^3.1.0",
-            "csscolorparser": "~1.0.3",
-            "earcut": "^2.2.3",
-            "geojson-vt": "^3.2.1",
-            "gl-matrix": "^3.3.0",
-            "grid-index": "^1.1.0",
-            "minimist": "^1.2.5",
-            "murmurhash-js": "^1.0.0",
-            "pbf": "^3.2.1",
-            "potpack": "^1.0.1",
-            "quickselect": "^2.0.0",
-            "rw": "^1.3.3",
-            "supercluster": "^7.1.4",
-            "tinyqueue": "^2.0.3",
-            "vt-pbf": "^3.1.3"
-          }
-        }
+        "@types/mapbox-gl": "^2.6.0"
       }
     },
     "react-refresh": {
@@ -25809,11 +25632,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -26967,14 +26785,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "viewport-mercator-project": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
-      "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
-      "requires": {
-        "@math.gl/web-mercator": "^3.5.5"
-      }
     },
     "vt-pbf": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-dev-utils": "^12.0.0",
     "react-dom": "^17.0.2",
     "react-leaflet": "^3.2.5",
-    "react-map-gl": "^6.1.19",
+    "react-map-gl": "^7.0.6",
     "react-refresh": "^0.11.0",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^5.0.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,6 +42,10 @@ function App() {
     }
   };
 
+  const lngLatToCoords = (lngLat) => [lngLat.lng, lngLat.lat];
+  const handleStartPointDrag = (evt) => setStartPoint(lngLatToCoords(evt.lngLat));
+  const handleEndPointDrag = (evt) => setEndPoint(lngLatToCoords(evt.lngLat));
+
   const fetchRoute = () => {
     if (!startPoint || !endPoint) {
       if (route) setRoute(null);
@@ -78,8 +82,8 @@ function App() {
         endPoint={endPoint}
         routeCoords={route && route.paths[0]}
         bbox={route && route.bboxes[0]}
-        onStartPointDrag={(evt) => setStartPoint(evt.lngLat)}
-        onEndPointDrag={(evt) => setEndPoint(evt.lngLat)}
+        onStartPointDrag={handleStartPointDrag}
+        onEndPointDrag={handleEndPointDrag}
       />
     </div>
   );

--- a/src/components/BikehopperMap.js
+++ b/src/components/BikehopperMap.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect } from 'react';
 import * as turf from '@turf/helpers';
 import MapGL, { Layer, Marker, Source } from 'react-map-gl';
 import MarkerSVG from './MarkerSVG';
@@ -11,27 +11,26 @@ function BikehopperMap(props) {
   const { startPoint, endPoint, routeCoords, bbox, onStartPointDrag, onEndPointDrag } = props;
   const mapRef = React.useRef();
 
-  const [viewport, setViewport] = useState({
+  const initialViewState = {
     // hardcode San Francisco view for now
     latitude: 37.75117670681911,
     longitude: -122.44574920654225,
     zoom: 12,
     bearing: 0,
     pitch: 0,
-  });
+  };
 
   const centerOnBbox = () => {
-    const map = mapRef.current.getMap();
-    if (!bbox) return;
+    const map = mapRef.current?.getMap();
+    if (!map || !bbox) return;
 
     const [minx, miny, maxx, maxy] = bbox;
-    const { center: { lng, lat }, zoom } = map.cameraForBounds([[minx, miny], [maxx, maxy]], {
+    map.fitBounds([[minx, miny], [maxx, maxy]], {
       padding: 40
     });
-    setViewport({ latitude: lat, longitude: lng, zoom, bearing: 0, pitch: 0 });
   }
 
-  React.useEffect(centerOnBbox, [bbox])
+  useEffect(centerOnBbox, [bbox])
 
   const layerStyle = {
     id: 'line',
@@ -44,13 +43,14 @@ function BikehopperMap(props) {
 
   return (
     <MapGL
-      {...viewport}
+      initialViewState={initialViewState}
       ref={mapRef}
-      width="100vw"
-      height="100vh"
+      style={{
+        width: '100vw',
+        height: '100vh',
+      }}
       mapStyle="mapbox://styles/mapbox/light-v9"
-      onViewportChange={setViewport}
-      mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
+      mapboxAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
     >
       {routeCoords && <Source type="geojson" data={turf.lineString(routeCoords)}>
         <Layer {...layerStyle} />


### PR DESCRIPTION
- upgrades ReactMapGL to 7, which:
  - allows us to use uncontrolled maps
  - fixes the immediate issue with controls not positioning correctly
    - (this PR does not add controls, but I've verified they work right on a different branch)
- does not upgrade MapLibre to 2
  - (I couldn't figure out how to work around its removal of support for mapbox:// URLs)
- while at it, upgrades every other dependency that isn't a breaking change
- converts map to an uncontrolled map