### PR TITLE
Add modeshare symbols at leg midpoints

### DIFF
--- a/src/components/BikehopperMap.js
+++ b/src/components/BikehopperMap.js
@@ -84,14 +84,15 @@ function BikehopperMap(props) {
     },
   };
 
-  const midpointStyle = {
-    id: 'midpointLayer',
+  const routeLabelStyle = {
+    id: 'routeLabelLayer',
     type: 'symbol',
     layout: {
-      'symbol-sort-key': getMidpointSortKey(activePath),
+      'symbol-sort-key': getLabelSortKey(activePath),
       'symbol-placement': 'line-center',
       'text-size': 16,
-      'text-field': getMidpointTextField(),
+      'text-field': getLabelTextField(),
+      'text-ignore-placement': true,
     },
     paint: {
       'text-color': getLegColorStyle(activePath),
@@ -116,8 +117,8 @@ function BikehopperMap(props) {
       <Source id="routeSource" type="geojson" data={routeFeatures}>
         <Layer {...legStyle} />
       </Source>
-      <Source id="midpointSymbols" type="geojson" data={routeFeatures}>
-        <Layer {...midpointStyle} />
+      <Source id="routeLabels" type="geojson" data={routeFeatures}>
+        <Layer {...routeLabelStyle} />
       </Source>
       {startPoint && (
         <Marker
@@ -153,8 +154,8 @@ function getLegSortKey(indexOfActivePath) {
   return ['case', ['==', ['get', 'path_index'], indexOfActivePath], 9999, 0];
 }
 
-function getMidpointSortKey(indexOfActivePath) {
-  return ['case', ['==', ['get', 'path_index'], indexOfActivePath], 0, 9999];
+function getLabelSortKey(indexOfActivePath) {
+  return ['case', ['==', ['get', 'path_index'], indexOfActivePath], 9999, 0];
 }
 
 function getLegColorStyle(indexOfActivePath) {
@@ -168,7 +169,7 @@ function getLegColorStyle(indexOfActivePath) {
   ];
 }
 
-function getMidpointTextField() {
+function getLabelTextField() {
   const text = [
     'case',
     ['==', ['get', 'type'], 'bike2'],


### PR DESCRIPTION
Currently this shows a text symbol at the midpoint, based on the route_name or 'bike', styled according to the leg's color.  For bike modes, the mock design shows a bike symbol, which we'll need to find a sprite/icon for, but that should be easy to plug in to this.

![image](https://user-images.githubusercontent.com/2773087/154427183-851c3ea9-b9ac-456c-9979-f2ab6fd4c23d.png)
