### PR TITLE
in dev, make API requests to same host

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,2 @@
-REACT_APP_BIKEHOPPER_DOMAIN=https://localhost:3000
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1IjoiMmpoazNicjJqZXF1IiwiYSI6ImNrejUzM2hxeDBobWYycG8wdzlpb3ppcjUifQ.dgo6QQyOJykr-m-2epbgGw"
 HTTPS=true

--- a/src/lib/BikehopperClient.js
+++ b/src/lib/BikehopperClient.js
@@ -6,9 +6,7 @@ export async function fetchRoute({
   signal,
 }) {
   const route = await fetch(
-    `${process.env.REACT_APP_BIKEHOPPER_DOMAIN}/v1/graphhopper/route-pt?point=${
-      points[0]
-    }&point=${
+    `${getRequestHost()}/v1/graphhopper/route-pt?point=${points[0]}&point=${
       points[1]
     }&locale=en-US&pt.earliest_departure_time=${encodeURIComponent(
       new Date().toISOString(),
@@ -30,7 +28,7 @@ export async function geocode(
   { limit = 1, format = 'geojson', signal },
 ) {
   const url = `${
-    process.env.REACT_APP_BIKEHOPPER_DOMAIN
+    getRequestHost()
   }/v1/nominatim/search?q=${encodeURIComponent(
     placeString,
   )}&limit=${limit}&format=${format}`;
@@ -50,4 +48,10 @@ export async function geocode(
   if (!geocoding.ok) throw new Error(geocoding.statusText);
 
   return geocoding.json();
+}
+
+function getRequestHost() {
+  if (process.env.NODE_ENV === 'development')
+    return window.location.protocol + '//' + window.location.host;
+  return process.env.REACT_APP_BIKEHOPPER_DOMAIN;
 }


### PR DESCRIPTION
I want to be able to go to a URL like `https://192.168.50.252:3000/` on my phone, to test Bikehopper on an actual mobile device as I develop.

This partially enables this, although the basemap is not showing because a request to Mapbox 403s.