### PR TITLE
fix display when a route has many legs, overflows

### DIFF
--- a/src/components/RoutesOverview.css
+++ b/src/components/RoutesOverview.css
@@ -26,12 +26,14 @@
 
 .RoutesOverview_timeEstimate {
   align-self: center;
+  flex-shrink: 0;
 }
 
 .RoutesOverview_routeLegs {
   padding-left: 0;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .RoutesOverview_leg,


### PR DESCRIPTION
this still doesn't look great, but makes it usable

# Before

![Screen Shot 2022-03-08 at 20 16 22](https://user-images.githubusercontent.com/1730853/157371768-6d3a8dd3-c513-492e-845d-c4ff19c02c09.png)

# After

![Screen Shot 2022-03-08 at 15 34 37](https://user-images.githubusercontent.com/1730853/157371635-d31659e6-0ed3-47ba-95ac-eb092c80087d.png)