### PR TITLE
resize map when its container changes

### DIFF
--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import useThrottledValue from './useThrottledValue';
+
+// Caution: this hook does not call the callback with the initial size when
+// first attaching to a node.
+
+export default function useResizeObserver(callback, throttleWait = 200) {
+  const [dimensionString, setDimensionString] = useState(null);
+  const observerRef = useRef(null);
+  const nodeRef = useRef(null);
+
+  const nodeCallbackRef = useCallback((newNode) => {
+    if (observerRef.current) {
+      if (nodeRef.current) observerRef.current.unobserve(nodeRef.current);
+      if (newNode) observerRef.current.observe(newNode);
+    }
+
+    nodeRef.current = newNode;
+  }, []);
+
+  useEffect(() => {
+    observerRef.current = new ResizeObserver((entries) => {
+      if (entries.length !== 1) {
+        console.error('expected only one resize entry');
+        return;
+      }
+
+      const { inlineSize: width, blockSize: height } =
+        entries[0].contentBoxSize[0];
+      setDimensionString(width + 'x' + height);
+    });
+
+    if (nodeRef.current) {
+      observerRef.current.observe(nodeRef.current);
+    }
+
+    return () => {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    };
+  }, [nodeRef]);
+
+  const throttledDimensionString = useThrottledValue(
+    dimensionString,
+    throttleWait,
+  );
+
+  useEffect(() => {
+    if (observerRef.current)
+      callback(
+        throttledDimensionString
+          ? throttledDimensionString.split('x')
+          : [null, null],
+      );
+  }, [callback, throttledDimensionString]);
+
+  return nodeCallbackRef;
+}

--- a/src/hooks/useThrottledValue.js
+++ b/src/hooks/useThrottledValue.js
@@ -1,0 +1,28 @@
+import { useState, useEffect, useRef } from 'react';
+
+export default function useThrottledValue(value, wait) {
+  const [throttledValue, setThrottledValue] = useState(value);
+  const lastSetRef = useRef(0);
+
+  useEffect(() => {
+    const now = Date.now();
+    const then = lastSetRef.current;
+    const elapsed = now - then;
+
+    if (elapsed >= wait) {
+      lastSetRef.current = now;
+      setThrottledValue(value);
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      setThrottledValue(value);
+    }, wait - elapsed);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [value, wait]);
+
+  return throttledValue;
+}


### PR DESCRIPTION
Fixes #39, where newly fetched routes weren't being centered.

We need the explicit resize call before calling fitBounds because it triggers before the ResizeObserver calls our callback (sadly there was no straightforward cleaner way to do this).

And we need the ResizeObserver to resize the map again when routes are cleared (or in the future when the pane is resized).