### PR TITLE
Use lat/long for custom marker drags

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -179,6 +179,9 @@ function _describeLocation(loc) {
   if (!loc) return '';
   if (loc.source === LocationSourceType.UserGeolocation)
     return 'Current Location';
-  if (loc.source === LocationSourceType.Marker) return 'Custom';
+  if (loc.source === LocationSourceType.Marker) {
+    const [long, lat] = loc.point.geometry.coordinates;
+    return `${lat.toFixed(5)},${long.toFixed(5)}`;
+  }
   return describePlace(loc.point);
 }


### PR DESCRIPTION
Fixes #74 

google maps displays lat long while their reverse geocoder runs. made #78 to capture that, but that seems like a bigger lift and i like this for now