### PR TITLE
fix square border; show more suggestions

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -50,7 +50,7 @@ function App() {
     <div className="App">
       <TopBar
         showSearchBar={isEditingLocations || hasLocations || hasRoutes}
-        showDirectionsLabel={isEditingLocations}
+        initiallyFocusDestination={isEditingLocations}
       />
       {showMap && <BikehopperMap />}
       {bottomContent && (

--- a/src/components/SearchBar.css
+++ b/src/components/SearchBar.css
@@ -8,8 +8,8 @@
 
 .SearchBar_input {
   background-color: #def0cc;
-  border: none;
-  padding: 12px 12px 12px 40px;
+  border: 2px solid transparent;
+  padding: 10px 10px 10px 34px;
   border-radius: 12px;
   width: 100%;
   font-size: 13px;
@@ -17,7 +17,7 @@
 
 .SearchBar_divider {
   display: block;
-  height: 21px;
+  height: 16px;
   border-left: 3px dotted white;
   margin-left: 19px;
 }
@@ -28,11 +28,12 @@
 
 .SearchBar_icon {
   position: absolute;
-  top: 8px;
+  top: 10px;
   left: 8px;
 }
 
 .SearchBar_input:focus {
   background-color: #fff;
-  outline: #ffd18e solid 2px; /* FIXME: would look better INSIDE the input */
+  outline: none;
+  border: 2px solid #ffd18e;
 }

--- a/src/components/SelectionListItem.css
+++ b/src/components/SelectionListItem.css
@@ -1,5 +1,5 @@
 .SelectionListItem {
-  padding: 14px 24px;
+  padding: 8px 24px;
 }
 
 .SelectionListItem:not(:last-child) {
@@ -17,6 +17,6 @@
 }
 
 .SelectionListItem_link {
-  padding: 14px 24px;
+  padding: 8px 24px;
   flex-grow: 1;
 }

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -1,6 +1,6 @@
 .TopBar {
   background-color: #5aaa0a;
-  padding: 20px 24px;
+  padding: 16px 24px;
   display: flex;
   flex-flow: column;
   align-items: stretch;
@@ -31,10 +31,4 @@
 .TopBar_info {
   top: 2px; /* damn I need to remove the default fr */
   height: 27px;
-}
-
-.TopBar_getDirections {
-  font-size: 18px;
-  margin: 0 0 20px 0;
-  color: #fff;
 }

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -5,7 +5,7 @@ import { ReactComponent as InfoEmpty } from 'iconoir/icons/info-empty.svg';
 
 import './TopBar.css';
 
-export default function TopBar({ showSearchBar, showDirectionsLabel }) {
+export default function TopBar({ showSearchBar, initiallyFocusDestination }) {
   const logoAndInfoButton = (
     <div className="TopBar_logoAndInfoButton">
       <span className="TopBar_logo">
@@ -21,11 +21,8 @@ export default function TopBar({ showSearchBar, showDirectionsLabel }) {
   return (
     <div className="TopBar">
       {!showSearchBar && logoAndInfoButton}
-      {showSearchBar && showDirectionsLabel && (
-        <h2 className="TopBar_getDirections">Get directions</h2>
-      )}
       {showSearchBar && (
-        <SearchBar initiallyFocusDestination={showDirectionsLabel} />
+        <SearchBar initiallyFocusDestination={initiallyFocusDestination} />
       )}
     </div>
   );


### PR DESCRIPTION
- Fixes square highlight border on mobile Safari
- Mitigates #90 somewhat. I don't consider this a full solution, but by removing the "Get directions" label and reducing padding, we can at least sort of fit 2 suggestions on screen instead of 1.

Before at left, After at right

![edgewood](https://user-images.githubusercontent.com/1730853/163078452-145396f6-8f44-4d5d-ad28-18efc24ff3d3.png)
