### PR TITLE
dynamic transit color darkening

### DIFF
--- a/src/components/BikehopperMap.js
+++ b/src/components/BikehopperMap.js
@@ -329,8 +329,8 @@ function getTransitLabelStyle(activePath) {
       'text-allow-overlap': true,
     },
     paint: {
-      'text-color': 'white',
-      'text-halo-color': getTransitColorStyle(activePath),
+      'text-color': ['get', 'text_color'],
+      'text-halo-color': getTransitColorStyle(activePath, 'text_halo_color'),
       'text-halo-width': 2,
     },
   };
@@ -389,12 +389,12 @@ function getLegSortKey(indexOfActivePath) {
   return ['case', ['==', ['get', 'path_index'], indexOfActivePath], 9999, 0];
 }
 
-function getTransitColorStyle(indexOfActivePath) {
+function getTransitColorStyle(indexOfActivePath, colorKey = 'route_color') {
   return [
     'case',
     ['==', ['get', 'path_index'], indexOfActivePath],
     // for active path use the route color from GTFS or fallback to blue
-    ['to-color', ['get', 'route_color'], '#5aaa0a'],
+    ['to-color', ['get', colorKey], '#5aaa0a'],
     // inactive paths are darkgray
     ['to-color', 'darkgray'],
   ];

--- a/src/components/RouteLeg.js
+++ b/src/components/RouteLeg.js
@@ -18,7 +18,7 @@ export default function RouteLeg(props) {
     );
   } else if (props.type === 'pt') {
     const bgColor = props.routeColor != null ? '#' + props.routeColor : 'blue';
-    const fgColor = getTextColor(props.routeColor);
+    const fgColor = getTextColor(props.routeColor).main;
     mode = (
       <span
         className="RouteLeg_transitMode"

--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -17,8 +17,8 @@ export function getTextColor(legColorString) {
 
   const color = Color(`#${legColorString}`);
   if (color.luminosity() > 0.5) {
-    return 'black';
+    return { main: 'black', halo: color.lighten(0.4).hex() };
   } else {
-    return 'white';
+    return { main: 'white', halo: darkenLegColor(legColorString) };
   }
 }

--- a/src/lib/geometry.js
+++ b/src/lib/geometry.js
@@ -23,10 +23,13 @@ export function routesToGeoJSON(paths) {
     for (let legIdx = 0; legIdx < path.legs.length; legIdx++) {
       const leg = path.legs[legIdx];
 
+      const legColor = darkenLegColor(leg.route_color);
+      const textColor = getTextColor(leg.route_color);
       // Add a LineString feature for the leg
       const legFeature = turf.lineString(leg.geometry.coordinates, {
-        route_color: darkenLegColor(leg.route_color),
-        text_color: getTextColor(leg.route_color),
+        route_color: legColor,
+        text_color: textColor.main,
+        text_halo_color: textColor.halo,
         route_name: leg.route_name,
         label: leg.route_name,
         type: leg.type,


### PR DESCRIPTION
makes BART yellow less eye searing

![image](https://user-images.githubusercontent.com/1449257/164125379-afedc1ab-fee8-4632-a131-bcd070a14263.png)


while not making other colors too dark
![image](https://user-images.githubusercontent.com/1449257/164125460-122a6dc7-fb24-46e7-8d80-448e9ff229b8.png)
