### PR TITLE
Address clipping of UI at the bottom on Android

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -231,8 +231,7 @@ function App() {
   React.useEffect(() => {
     if (VisualViewportTracker.isSupported()) {
       VisualViewportTracker.listen((height) => {
-        document.body.style.height =
-          window.innerHeight > height + 100 ? `${height}px` : '';
+        document.body.style.height = Math.floor(height) + 'px';
       });
     }
   }, []);

--- a/src/lib/VisualViewportTracker.js
+++ b/src/lib/VisualViewportTracker.js
@@ -10,7 +10,7 @@ let _lastHeight;
 
 export function isSupported() {
   const ua = Bowser.parse(navigator.userAgent);
-  return ua.os.name === 'iOS' && !!window.visualViewport;
+  return !!window.visualViewport;
 }
 
 export function init() {


### PR DESCRIPTION
The problem on Android is the visual viewport resize height is equal to `window.innerHeight`, and both values account for the address bar being expanded, BUT `100vh` does NOT account for the address bar being expanded.

Example:
Assume address bar is 50px and screen is 750px.
In that case,
`window.innerHeight = 700px` ( 750 - 50)
but 
`1vh = 750/100 = 7.5px`

So the fix is not rely on `vh` at all for the body height, instead always update it from resize events in JS.
`window.visualViewport` resizes also fire on vanilla `window` resizes so only need to listen to one.