### PR TITLE
Fix highlight on datetime

### DIFF
--- a/src/components/TimeBar.css
+++ b/src/components/TimeBar.css
@@ -38,10 +38,16 @@
   height: 35px;
   font-size: 12px;
   font-family: inherit;
+  color: inherit;
   background-color: #def0cc;
   border: 2px solid transparent;
   border-radius: 12px;
 }
 .TimeBar_datetime:disabled {
   display: none;
+}
+.TimeBar_datetime:focus {
+  background-color: #fff;
+  outline: none;
+  border: 2px solid #ffd18e;
 }


### PR DESCRIPTION
Looks like this now, which is the same highlight as the other inputs

![image](https://user-images.githubusercontent.com/2773087/165398749-ff1f6e6e-a32f-4dfd-ab4a-154d46831170.png)
