### PR TITLE
correct trip times

### DIFF
--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -50,7 +50,10 @@ export default function RoutesOverview(props) {
               ))}
             </ul>
             <p className="RoutesOverview_timeEstimate">
-              {formatInterval(route.time)}
+              {formatInterval(
+                new Date(route.legs[route.legs.length - 1].arrival_time) -
+                  new Date(route.legs[0].departure_time),
+              )}
             </p>
           </div>
           <DepartArriveTime


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1730853/165405345-a0f8b549-777d-43ac-8852-30922e67fc05.png)

Trip durations now reflect the time in transit, rather than the time since you requested the itinerary.

Fixes #81