### PR TITLE
Hardcode API domains for staging/prod

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,4 @@
-REACT_APP_BIKEHOPPER_DOMAIN=https://localhost:3000
-# select local or deployed graphhopper instance
-REACT_APP_GRAPHHOPPER_PATH = "${REACT_APP_BIKEHOPPER_DOMAIN}/v1/graphhopper"
-# REACT_APP_GRAPHHOPPER_PATH = http://localhost:8989
+# To select local, rather than deployed, graphhopper instance:
+#REACT_APP_USE_LOCAL_GRAPHHOPPER = http://localhost:8989
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1IjoiMmpoazNicjJqZXF1IiwiYSI6ImNrejUzM2hxeDBobWYycG8wdzlpb3ppcjUifQ.dgo6QQyOJykr-m-2epbgGw"
 HTTPS=true

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,1 @@
-REACT_APP_BIKEHOPPER_DOMAIN=https://api-bikehopper-staging.techlabor.org
-REACT_APP_GRAPHHOPPER_PATH = "${REACT_APP_BIKEHOPPER_DOMAIN}/v1/graphhopper"
 REACT_APP_MAPBOX_TOKEN="pk.eyJ1IjoiMmpoazNicjJqZXF1IiwiYSI6ImNrejUzM2hxeDBobWYycG8wdzlpb3ppcjUifQ.dgo6QQyOJykr-m-2epbgGw"


### PR DESCRIPTION
Closes #95

In staging and prod, a hardcoded mapping of app domain -> API domain will be used. Not ideal, but see discussion in #95

In development, I've stopped hardcoding localhost. This is more flexible: instead of using localhost you can use a local network address such as `https://192.168.1.1:3000/` to access your local instance of the UI from your phone.

In development when you want to use a local GraphHopper instance, the name of the environment constant to define will now change from `REACT_APP_GRAPHHOPPER_PATH` to `REACT_APP_USE_LOCAL_GRAPHHOPPER` to clarify that it's an override for development only