### PR TITLE
add info & feedback link to startup screen

### DIFF
--- a/src/components/DirectionsNullState.css
+++ b/src/components/DirectionsNullState.css
@@ -1,6 +1,5 @@
 .DirectionsNullState {
-  /* extra padding on bottom to work around mobile Safari expanding address bar */
-  padding: 24px 24px 82px 24px;
+  padding: 24px;
 }
 
 .DirectionsNullState_header {
@@ -18,10 +17,27 @@
 
 .DirectionsNullState_inputContainer {
   position: relative;
+  margin-bottom: 20px;
 }
 
 .DirectionsNullState_inputIcon {
   position: absolute;
   top: -2px;
   left: 8px;
+}
+
+.DirectionsNullState_para {
+  margin: 20px 0;
+  font-size: 14px;
+}
+
+.DirectionsNullState_para a {
+  text-decoration: underline;
+  color: rgb(0, 104, 224);
+}
+
+@media (max-width: 899px) {
+  .DirectionsNullState_wideScreenOnly {
+    display: none;
+  }
 }

--- a/src/components/DirectionsNullState.js
+++ b/src/components/DirectionsNullState.js
@@ -22,6 +22,29 @@ export default function DirectionsNullState(props) {
           onFocus={props.onInputFocus}
         />
       </span>
+      <p className="DirectionsNullState_para">
+        <strong>Welcome to BikeHopper!</strong> This is a new bike navigation
+        app that suggests ways to combine biking and transit, expanding your
+        options for getting around without a car.
+      </p>
+      <p className="DirectionsNullState_para">
+        Get started by entering a destination and starting point above, or tap
+        the "find my location" button in the top right corner of the map to get
+        directions from your current location.
+      </p>
+      <p className="DirectionsNullState_para DirectionsNullState_wideScreenOnly">
+        In this early beta, BikeHopper is{' '}
+        <strong>designed for phone screens</strong>, so it might look strange on
+        your computer.
+      </p>
+      <p className="DirectionsNullState_para">
+        Let us know what you think by reporting bugs, routes that could be
+        better, and other feedback in{' '}
+        <a href="https://forms.gle/ggVFjztFN6ivLEAu9" target="_blank">
+          this form
+        </a>
+        !
+      </p>
     </div>
   );
 }

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import Icon from './Icon';
 import SearchBar from './SearchBar';
-import { ReactComponent as InfoEmpty } from 'iconoir/icons/info-empty.svg';
 
 import './TopBar.css';
 
@@ -12,9 +10,7 @@ export default function TopBar({ showSearchBar, initiallyFocusDestination }) {
         <span className="TopBar_logoBike">Bike</span>
         <span className="TopBar_logoHopper">Hopper</span>
       </span>
-      <Icon className="TopBar_info" label="Info">
-        <InfoEmpty />
-      </Icon>
+      {/* temporarily removed info button until we have something to show */}
     </div>
   );
 


### PR DESCRIPTION
Temporarily removes info button (thus fixes #86) but doesn't completely remove the CSS as I want to redesign this soon and put the button back.

Adds some basic info about BikeHopper and a link to [this feedback form](https://forms.gle/ggVFjztFN6ivLEAu9) to appear on the startup screen.

When you first load BikeHopper, you'll see this:

![start-screen-0](https://user-images.githubusercontent.com/1730853/165670625-e264e849-8a45-48fa-bbac-43bcadf12cd0.png)

And after scrolling down:

![start-screen](https://user-images.githubusercontent.com/1730853/165670636-7b38a5ac-0e0b-4912-bb47-6e7e845c3a70.png)

There's also a warning about it being designed for phones that shows up only on wide screens.