### PR TITLE
Fix text alignment on long bike direction

### DIFF
--- a/src/components/ItineraryBikeStep.css
+++ b/src/components/ItineraryBikeStep.css
@@ -1,6 +1,7 @@
 .ItineraryBikeStep_btn {
   border: none;
   background: none;
+  color: inherit;
   font-size: inherit;
   font-weight: inherit;
   padding: 0;


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/1730853/165890241-6454ff06-dad5-46d4-8bd9-33a0345a1d0c.png)

caused by word-wrapping