### PR TITLE
Fix autocomplete results flickering

### DIFF
--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -27,7 +27,7 @@ export default function SearchAutocompleteDropdown(props) {
 
       let inputText = state.routeParams[startOrEnd + 'InputText'];
       let cache = inputText && state.geocoding.cache['@' + inputText.trim()];
-      if (!cache) {
+      if (!cache || cache.status !== 'succeeded') {
         // If the location we're editing has a geocoded location already selected, display the
         // other options from the input text that was used to pick that.
         const relevantLocation = state.routeParams[startOrEnd];
@@ -43,7 +43,11 @@ export default function SearchAutocompleteDropdown(props) {
           // "123 Main St" which hasn't been looked up yet but we have results for "123 Mai",
           // which came back while you were typing.
           let strippedChars = 0;
-          while (inputText && !cache && strippedChars++ < 8) {
+          while (
+            inputText &&
+            (!cache || cache.status !== 'succeeded') &&
+            strippedChars++ < 8
+          ) {
             inputText = inputText.substr(0, inputText.length - 1);
             cache = state.geocoding.cache['@' + inputText.trim()];
           }


### PR DESCRIPTION
A while back I wrote code to try to provide more useful autocomplete results by looking back: If we have autocomplete results for "Glen Ca" but no results for the current contents of the input box which are "Glen Cany", remove letters until we do find results so that Glen Canyon Park can be displayed as a suggestion.

This was never quite working though, because it only tried removing letters if there was no cache record at all, but gave up immediately if there was a cache record in the "fetching" state. In other words, this set of events could happen:

1. Type "Glen Ca", pause for autocomplete results for "Glen Ca" tocome back
2. Type "ny". Since there is no cache record for "Glen Cany", we try removing letters, and you still get the same results as in step 1
3. After the 700ms debounce delay, we kick off a fetch for "Glen Cany" and create a cache record for this key with status "fetching". Your search results now DISAPPEAR
4. Finally, autocomplete results for "Glen Cany" come back, and the entry for Glen Canyon Park, having disappeared, reappears
