### PR TITLE
Make "Current Location" a routing option at all times

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -12,7 +12,7 @@ import SearchAutocompleteDropdown from './SearchAutocompleteDropdown';
 import TopBar from './TopBar';
 import {
   LocationSourceType,
-  locationInputFocused,
+  enterDestinationFocused,
 } from '../features/routeParams';
 import * as VisualViewportTracker from '../lib/VisualViewportTracker';
 
@@ -245,7 +245,7 @@ function App() {
     document.body.scrollTop = 0;
     document.documentElement.scrollTop = 0;
     evt.preventDefault();
-    dispatch(locationInputFocused('end'));
+    dispatch(enterDestinationFocused());
   };
 
   const mapOverlayRef = React.useRef();

--- a/src/features/geolocation.js
+++ b/src/features/geolocation.js
@@ -43,18 +43,18 @@ export function geolocated(coords, timestamp) {
   };
 }
 
-// Not yet used or tested.
-// TODO: Call this when "Current Location" is used in a location input and
-// enable that option even if the geolocate control has not been touched.
-export function geolocate(maxAge, timeout) {
+const MAX_AGE_MS = 30000;
+const TIMEOUT_MS = 15000;
+
+export function geolocate() {
   return async function geolocateThunk(dispatch, getState) {
     dispatch({ type: 'geolocate_attempted' });
 
     let pos;
     try {
       pos = await getCurrentPosition({
-        maximumAge: maxAge,
-        timeout,
+        maximumAge: MAX_AGE_MS,
+        timeout: TIMEOUT_MS,
       });
     } catch (e) {
       const errorCode =

--- a/src/features/routes.js
+++ b/src/features/routes.js
@@ -47,7 +47,6 @@ export function routesReducer(state = DEFAULT_STATE, action) {
         return state;
       }
     case 'geocoded_location_selected':
-    case 'current_location_selected':
       // As above, clear route if need be
       if (
         state.routes &&
@@ -62,6 +61,8 @@ export function routesReducer(state = DEFAULT_STATE, action) {
       } else {
         return state;
       }
+    case 'current_location_selected':
+      return _clearRoutes(state);
     case 'route_fetch_attempted':
       return produce(state, (draft) => {
         draft.routes = draft.activeRoute = null;


### PR DESCRIPTION
This changes the routeParams state in that now it is possible for start or end location to be non-null, while start.point or end.point respectively IS null.

The "locations submitted" action creator previously was only used when you "submitted the form" (on desktop: press Enter key while in a textbox; on mobile: tap "Return" (iPhone) or right arrow (Android) button in the virtual keyboard). It attempted to hydrate location text strings by calling out asynchronously to the geocoder.

With this commit, the "locations submitted" action creator also hydrates location objects of the shape

    {
      point: null,
      source: LocationSourceType.UserGeolocation,
    },

by asynchronously waiting for geolocation, and it is both called directly upon form submission *and* indirectly as a helper function by several other actions that update route params and may result in a route fetch. (Which, yes, implies that those action creators now also fire "locations_set" actions.)

That's the core of the change. Also:

Previously, we quietly defaulted the start location to your current location once we received geolocation data (as a result of you tapping the geolocate button in the corner of the map). This was a hacky way of setting a default which required further hacks to avoid displaying a marker on the map in that case. This commit defaults the start location to current location when you enter the location input step from the null state.

The SearchBar component and routeParams reducer have been updated to make it possible to clear out the "Current Location" setting by modifying the text of the input in question. The way this commit does this is a little hacky and I would be open to revisiting it in the future.

Previously, the start and end marker displayed on the map were always based on the routeParams.start and .end. With this commit, if we have routes, we will instead display the routeStartCoords/EndCoords. This mostly doesn't matter right now, but it's logically more correct. For example, if you request directions from "Current Location," and then walk a few blocks away, we might update routeParams.start.point to reflect updated geolocation. (This commit doesn't do that, but in the future, we might do that.) On the map we would still want the start marker to be where the directions start.

Previously, we always displayed "Current Location" at the top of the autocomplete if it was a possible option to select. I feel this can get in the way of finding the place I'm looking for, so this commit only shows the "Current Location" if you haven't typed anything, or what you have typed is a case-insensitive prefix of the string "Current Location". In other words, if you type "curr" you can either choose your current location or the Curran Theater on Geary, but once you type "curran" you only get the theater.

Fixes #87