### PR TITLE
Transit leg: Correct stop counts

### DIFF
--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -18,7 +18,8 @@ export default function ItineraryTransitLeg({ leg }) {
   const icon = ItineraryHeaderIcons.BUS;
   const agency = getAgencyNameForDisplay(leg.agency_name);
 
-  const stopDetail = `${stops.length} stop${stops.length > 1 && 's'}`;
+  const stopsTraveled = stops.length - 1;
+  const stopsBetweenStartAndEnd = stopsTraveled - 1;
   return (
     <>
       <ItineraryHeader icon={icon} iconColor={leg.route_color}>
@@ -26,7 +27,7 @@ export default function ItineraryTransitLeg({ leg }) {
           Ride the {leg.route_name} {mode} ({agency})
         </span>
         <span>
-          {stops.length} stop{stops.length > 1 && 's'} &middot;{' '}
+          {pluralizedStopCount(stopsTraveled)} &middot;{' '}
           {formatDurationBetween(leg.departure_time, leg.arrival_time)}
         </span>
       </ItineraryHeader>
@@ -34,7 +35,14 @@ export default function ItineraryTransitLeg({ leg }) {
       <ItineraryStep IconSVGComponent={Circle} smallIcon={true}>
         Board at <strong>{stops[0].stop_name}</strong> &middot; {departure}
       </ItineraryStep>
-      <ItineraryDivider transit={true} detail={stopDetail}>
+      <ItineraryDivider
+        transit={true}
+        detail={
+          stopsBetweenStartAndEnd > 0
+            ? pluralizedStopCount(stopsBetweenStartAndEnd) + ' before'
+            : null
+        }
+      >
         Towards {leg.trip_headsign}
       </ItineraryDivider>
       <ItineraryStep IconSVGComponent={Circle} smallIcon={true}>
@@ -44,4 +52,8 @@ export default function ItineraryTransitLeg({ leg }) {
       <ItineraryDivider />
     </>
   );
+}
+
+function pluralizedStopCount(numStops) {
+  return `${numStops} stop${numStops > 1 ? 's' : ''}`;
 }


### PR DESCRIPTION
If you travel from 16th Street BART, past 24th Street BART, and get off at Glen Park BART, you have traveled 2 stops, not 3.

And the number of stops between where you boarded and where you got off is 1, not 3.

This corrects the stop counts to what you would expect to see.

example 1:
![image](https://user-images.githubusercontent.com/1730853/168163696-709844e3-7c0d-4034-ab1b-156ab0c89cfd.png)

example 2:
![image](https://user-images.githubusercontent.com/1730853/168164097-82532433-78ef-4d38-a206-9c18a71d7506.png)
