### PR TITLE
Make transitions use default bike color (asphalt gray)

### DIFF
--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -4,6 +4,7 @@ export const DEFAULT_BIKE_COLOR = '#5c5c3d';
 export const DEFAULT_PT_COLOR = '#4169e1';
 export const DEFAULT_INACTIVE_COLOR = 'darkgray';
 export const BIKEHOPPER_THEME_COLOR = '#5aaa0a';
+export const TRANSITION_COLOR = DEFAULT_BIKE_COLOR;
 
 export function darkenLegColor(legColorString) {
   if (legColorString == null) return null;

--- a/src/lib/geometry.js
+++ b/src/lib/geometry.js
@@ -7,6 +7,7 @@ import {
   darkenLegColor,
   DEFAULT_BIKE_COLOR,
   DEFAULT_PT_COLOR,
+  TRANSITION_COLOR,
   getTextColor,
 } from './colors.js';
 
@@ -57,6 +58,7 @@ export function routesToGeoJSON(paths) {
           properties: {
             path_index: pathIdx,
             type: leg.type,
+            route_color: TRANSITION_COLOR,
           },
           resolution: 1000,
         });


### PR DESCRIPTION
We never explicitly decided on a color for transition curves between legs, and were falling back to the green BikeHopper theme color until the pull request #109 removed that default, leading to a console warning from MapLibre and defaulting to black.

For lack of a better idea, I'm specifying the transition curves will be asphalt gray, same as used for bike routing on streets without bike infrastructure.

Example:

![image](https://user-images.githubusercontent.com/1730853/168404220-7cae3a8b-0a8e-4ee1-8965-52e403e99f77.png)

Fixes #141