### PR TITLE
Itinerary spacing and formatting improvements

### DIFF
--- a/src/components/ItineraryBikeLeg.js
+++ b/src/components/ItineraryBikeLeg.js
@@ -5,6 +5,7 @@ import InstructionSigns from '../lib/InstructionSigns';
 import ItineraryBikeStep from './ItineraryBikeStep';
 import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
+import ItinerarySpacer from './ItinerarySpacer';
 
 export default function ItineraryBikeLeg({ leg, legDestination, onStepClick }) {
   return (
@@ -36,6 +37,7 @@ export default function ItineraryBikeLeg({ leg, legDestination, onStepClick }) {
               />,
             ],
       )}
+      <ItinerarySpacer />
     </>
   );
 }

--- a/src/components/ItineraryDivider.css
+++ b/src/components/ItineraryDivider.css
@@ -1,17 +1,8 @@
-.ItineraryDivider_border {
-  width: 3px;
-  background-color: #bbb;
-  height: 100%;
-  display: inline-block;
-  margin-left: 30px;
-}
-
 .ItineraryDivider_subheading {
   font-weight: bold;
-  font-size: 16px;
-  line-height: 16px;
-  margin-bottom: 6px;
-  margin-top: 6px;
+  font-size: 14px;
+  line-height: 14px;
+  margin: 0 0 8px;
 }
 
 .ItineraryDivider_subheadingTransit {
@@ -22,10 +13,25 @@
   color: #438601;
 }
 
-.ItineraryDivider_detail {
+.ItineraryDivider_horizontalRule {
   color: #626262;
   font-size: 12px;
   line-height: 12px;
   margin-bottom: 12px;
-  margin-top: 6px;
+  margin-top: 8px;
+  display: inline-block;
+  height: 12px;
+
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) calc(50% - 1px),
+    rgba(187, 187, 187, 1) 50%,
+    rgba(0, 0, 0, 0) 50%
+  );
+}
+
+.ItineraryDivider_detail {
+  background: white;
+  margin-left: 9px;
+  padding: 0 5px;
 }

--- a/src/components/ItineraryDivider.js
+++ b/src/components/ItineraryDivider.js
@@ -5,21 +5,25 @@ import ItineraryRow from './ItineraryRow';
 import './ItineraryDivider.css';
 
 export default function ItineraryDivider(props) {
-  const { transit, detail } = props;
+  const { transit, detail, children: subheading } = props;
 
   return (
     <ItineraryRow>
-      <span className="ItineraryDivider_border" />
-      <span
-        className={classnames({
-          ItineraryDivider_subheading: true,
-          ItineraryDivider_subheadingBike: !transit,
-          ItineraryDivider_subheadingTransit: transit,
-        })}
-      >
-        {props.children}
+      {'' /* no content for timeline side of row */}
+      {subheading && (
+        <span
+          className={classnames({
+            ItineraryDivider_subheading: true,
+            ItineraryDivider_subheadingBike: !transit,
+            ItineraryDivider_subheadingTransit: transit,
+          })}
+        >
+          {subheading}
+        </span>
+      )}
+      <span className="ItineraryDivider_horizontalRule">
+        {detail && <span className="ItineraryDivider_detail">{detail}</span>}
       </span>
-      <span className={'ItineraryDivider_detail'}>{detail}</span>
     </ItineraryRow>
   );
 }

--- a/src/components/ItineraryHeader.css
+++ b/src/components/ItineraryHeader.css
@@ -31,5 +31,5 @@
 .ItineraryHeader_subheading {
   font-weight: normal;
   font-size: 16px;
-  margin: 0;
+  margin: 8px 0;
 }

--- a/src/components/ItineraryRow.css
+++ b/src/components/ItineraryRow.css
@@ -9,6 +9,14 @@
   margin-right: 18px;
   box-sizing: border-box;
   flex-shrink: 0;
+
+  /* Draws the literal time*line* ... a dark gray line going down the middle. */
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0) 30px,
+    rgba(187, 187, 187, 1) 30px 33px,
+    rgba(0, 0, 0, 0) 33px 100%
+  );
 }
 
 .ItineraryRow_content {

--- a/src/components/ItinerarySpacer.css
+++ b/src/components/ItinerarySpacer.css
@@ -1,0 +1,3 @@
+.ItinerarySpacer {
+  margin: 12px 0 0;
+}

--- a/src/components/ItinerarySpacer.js
+++ b/src/components/ItinerarySpacer.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import ItineraryRow from './ItineraryRow';
+
+import './ItinerarySpacer.css';
+
+export default function ItinerarySpacer(props) {
+  return (
+    <ItineraryRow>
+      {'' /* no content for timeline side of row */}
+      <span className="ItinerarySpacer" />
+    </ItineraryRow>
+  );
+}

--- a/src/components/ItineraryStep.css
+++ b/src/components/ItineraryStep.css
@@ -8,7 +8,7 @@
 
 .ItineraryStep_iconSmall {
   margin-left: 9px;
-  top: 2px;
+  top: 10px;
 }
 
 .ItineraryStep_iconSmall path {
@@ -16,5 +16,9 @@
 }
 
 .ItineraryStep_content {
-  margin: 0;
+  margin: 8px 0;
+}
+
+.ItineraryStep_iconSvg {
+  background: white;
 }

--- a/src/components/ItineraryStep.js
+++ b/src/components/ItineraryStep.js
@@ -22,7 +22,11 @@ export default function ItineraryStep(props) {
             ItineraryStep_iconSmall: smallIcon,
           })}
         >
-          <IconSVGComponent width={iconSize} height={iconSize} />
+          <IconSVGComponent
+            className="ItineraryStep_iconSvg"
+            width={iconSize}
+            height={iconSize}
+          />
         </Icon>
       </span>
       <p className="ItineraryStep_content">{props.children}</p>

--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -3,6 +3,7 @@ import { formatTime, formatDurationBetween } from '../lib/time';
 import getAgencyNameForDisplay from '../lib/getAgencyNameForDisplay';
 import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
+import ItinerarySpacer from './ItinerarySpacer';
 import ItineraryStep from './ItineraryStep';
 
 import { ReactComponent as Circle } from 'iconoir/icons/circle.svg';
@@ -50,6 +51,7 @@ export default function ItineraryTransitLeg({ leg }) {
         {arrival}
       </ItineraryStep>
       <ItineraryDivider />
+      <ItinerarySpacer />
     </>
   );
 }


### PR DESCRIPTION
Fixes #148, fixes #149, and various tweaks to make the formatting look nicer.

Before and After:

![beforeandafter](https://user-images.githubusercontent.com/1730853/168412620-7c5c89c5-975f-4252-abd0-032ca4b801e9.png)

And with bike infrastructure info (This isn't actually implemented yet, I just made it always say "Bike lane" to preview how it would look):

![withbikelaneinfo](https://user-images.githubusercontent.com/1730853/168411220-d0bd53aa-e6e8-4ccd-94d5-6ec2d4aff1ec.png)
