### PR TITLE
Limit map to bounds of data cutout

### DIFF
--- a/src/components/BikehopperMap.js
+++ b/src/components/BikehopperMap.js
@@ -195,6 +195,7 @@ const BikehopperMap = React.forwardRef((props, mapRef) => {
     <div className="BikehopperMap" ref={resizeRef}>
       <MapGL
         initialViewState={viewStateOnFirstRender.current}
+        maxBounds={MAP_MAX_BOUNDS}
         ref={mapRef}
         style={{
           // expand to fill parent container div
@@ -502,5 +503,15 @@ function propIs(key, ...values) {
 function pathIndexIs(index) {
   return ['==', ['get', 'path_index'], index];
 }
+
+// NorCal data cutout boundaries, computed from the .poly file at:
+// https://download.geofabrik.de/north-america/us/california/norcal.html
+//
+// west, south, east, north order.
+//
+// In future, to better support BikeHopper instances in other regions, we may
+// want to move this to a config file, or compute it automatically from the
+// data cutout in use.
+const MAP_MAX_BOUNDS = [-125.8935, 35.78528, -115.6468, 42.01618];
 
 export default BikehopperMap;


### PR DESCRIPTION
Our data cutout is actually non-rectangular:

https://download.geofabrik.de/north-america/us/california/norcal.html

For now I'm erring on the permissive side and using a bounding box around this cutout, so it will be possible to request routes to/within Nevada that our GraphHopper server won't actually route to. (As well as large areas of NorCal that are not the Bay Area where we can do street routing but have no public transit data.)

Close enough. This avoids giving the false impression that you could use our BikeHopper instance to route you around Portland or Washington, DC or London.

Fixes #138