### PR TITLE
Apply bottom padding workaround to iOS Chrome too

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -44,17 +44,18 @@
   /* See below as well */
 }
 
-body.isMobileSafari .App_mapOverlayBottomPane {
+body.isIOSChromeOrSafari .App_mapOverlayBottomPane {
   /* Apple documentation suggests you can rely on env(safe-area-inset-bottom)
    * here, but it's 0 on iOS 15 on my iPhone SE 1st gen, despite the expanding
    * address bar. Apparently can't be relied upon. The fallback value below is
-   * empirically determined
+   * empirically determined and applies to Chrome and Safari on iOS but is not
+   * needed for some reason on Firefox for iOS
    */
   padding-bottom: max(env(safe-area-inset-bottom), 74px);
 }
 
 @media all and (display-mode: standalone) {
-  body.isMobileSafari .App_mapOverlayBottomPane {
+  body.isIOSChromeOrSafari .App_mapOverlayBottomPane {
     /* When running as a PWA, don't add extra padding */
     padding-bottom: env(safe-area-inset-bottom);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,12 @@ import store from './store';
 import './index.css';
 
 const ua = Bowser.parse(navigator.userAgent);
-if (ua.os.name === 'iOS' && ua.browser.name === 'Safari')
-  document.body.className += ' isMobileSafari';
+if (
+  ua.os.name === 'iOS' &&
+  (ua.browser.name === 'Chrome' || ua.browser.name === 'Safari')
+) {
+  document.body.className += ' isIOSChromeOrSafari';
+}
 
 render(
   <React.StrictMode>


### PR DESCRIPTION
A friend was getting the bug where they couldn't scroll to the last route. Didn't I squash that bug?? Well, turns out they were on Chrome for iOS.

It is not just mobile Safari that needs bottom padding to be able to scroll all the way to the bottom (and sometimes doesn't account for this in the safe-area-inset-bottom value), but Chrome on iOS too.

Firefox on iOS doesn't need it, surprisingly!