### PR TITLE
Correct error msgs when server 500s

### DIFF
--- a/src/features/geocoding.js
+++ b/src/features/geocoding.js
@@ -82,12 +82,20 @@ export function geocodeTypedLocation(text, key, { fromTextAutocomplete } = {}) {
         limit: GEOCODE_RESULT_LIMIT,
       });
     } catch (e) {
+      let failureType, alertMsg;
+      if (e instanceof BikehopperClient.BikehopperClientError) {
+        failureType = 'server error';
+        alertMsg = 'Server error';
+      } else {
+        failureType = 'network error';
+        alertMsg = "Can't connect to server";
+      }
       dispatch({
         type: 'geocode_failed',
         text,
-        failureType: 'network error',
+        failureType,
         time: Date.now(),
-        alert: alertOnFailure && { message: "Can't connect to server" },
+        alert: alertOnFailure && { message: alertMsg },
       });
       return;
     }

--- a/src/features/routes.js
+++ b/src/features/routes.js
@@ -188,14 +188,22 @@ export function fetchRoute(startCoords, endCoords, arriveBy, initialTime) {
     } catch (e) {
       console.error('route fetch failed:', e);
       let alertMessage = "Can't connect to server";
-      // GraphHopper sometimes 400s if it doesn't like the coordinates
-      if (e instanceof Error && e.message === 'Bad Request')
-        alertMessage = "Can't find a route";
+      let failureType = 'network error';
+      if (e instanceof BikehopperClient.BikehopperClientError) {
+        // GraphHopper sometimes 400s if it doesn't like the coordinates
+        if (e.message === 'Bad Request') {
+          alertMessage = "Can't find a route";
+          failureType = 'no route found';
+        } else {
+          alertMessage = 'Server error';
+          failureType = 'server error';
+        }
+      }
       dispatch({
         type: 'route_fetch_failed',
         startCoords,
         endCoords,
-        failureType: 'network error',
+        failureType,
         alert: { message: alertMessage },
       });
       return;

--- a/src/lib/BikehopperClient.js
+++ b/src/lib/BikehopperClient.js
@@ -17,6 +17,19 @@ function getApiPath() {
 
 const POINT_PRECISION = 5;
 
+export class BikehopperClientError extends Error {
+  constructor(response) {
+    super(response.statusText);
+    let json;
+    try {
+      json = response.json();
+    } catch (e) {}
+    this.code = response.code;
+    this.name = 'BikehopperClientError';
+    this.json = json;
+  }
+}
+
 export async function fetchRoute({
   profile = 'pt',
   connectingProfile = 'bike2',
@@ -63,7 +76,7 @@ export async function fetchRoute({
     signal,
   });
 
-  if (!route.ok) throw new Error(route.statusText);
+  if (!route.ok) throw new BikehopperClientError(route);
 
   return parse(await route.json());
 }
@@ -111,7 +124,7 @@ export async function geocode(
     signal,
   });
 
-  if (!geocoding.ok) throw new Error(geocoding.statusText);
+  if (!geocoding.ok) throw new BikehopperClientError(geocoding);
 
   return geocoding.json();
 }


### PR DESCRIPTION
Fixes #166

Tested via:

1. Find a departure time when the still unfixed router issue bikehopper/graphhopper#87 will cause GraphHopper to consistently 500. When requesting such a route, the alert says "Server error"

2. Shut down local dev server so the localhost proxy will not be reachable and fetch a route. Alert says "Can't connect to server"

3. After restarting local dev server fetch a route to the Greater Farallones Marine Sanctuary. Alert says "Can't find a route"

Geocoding errors:

4. With local dev server shut down (as in test case 2) attempt to geocode a new location string. Alert says "Can't connect to server"

5. With local dev server back up, try to geocode gibberish. Alert says "Can't find hgdsds crjgjefwe"

Missing test case: I'm not currently aware of a geocoding string that will cause Photon to 500, so I haven't tested that it says "Server error" in that case.  Hopefully I wrote the code right.