### PR TITLE
Make it possible to cancel a location edit

### DIFF
--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -131,5 +131,5 @@ export default function SearchAutocompleteDropdown(props) {
 // Hack for letting search bar see if an autocomplete result was focused
 export function isAutocompleteResultElement(domElement) {
   if (!domElement) return false;
-  return [].slice.call(domElement.classList).includes(LIST_ITEM_CLASSNAME);
+  return Array.from(domElement.classList).includes(LIST_ITEM_CLASSNAME);
 }

--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -15,6 +15,8 @@ import { ReactComponent as Position } from 'iconoir/icons/position.svg';
 
 import './SearchAutocompleteDropdown.css';
 
+const LIST_ITEM_CLASSNAME = 'SearchAutocompleteDropdown_place';
+
 export default function SearchAutocompleteDropdown(props) {
   const dispatch = useDispatch();
 
@@ -97,7 +99,7 @@ export default function SearchAutocompleteDropdown(props) {
     <SelectionList className="SearchAutocompleteDropdown">
       {showCurrentLocationOption && (
         <SelectionListItem
-          className="SearchAutocompleteDropdown_place"
+          className={LIST_ITEM_CLASSNAME}
           onClick={handleCurrentLocationClick}
         >
           <Icon className="SearchAutocompleteDropdown_icon">
@@ -110,7 +112,7 @@ export default function SearchAutocompleteDropdown(props) {
       )}
       {dedupedFeatures.map((feature, index) => (
         <SelectionListItem
-          className="SearchAutocompleteDropdown_place"
+          className={LIST_ITEM_CLASSNAME}
           key={feature.properties.osm_id + ':' + feature.properties.type}
           onClick={handleClick.bind(null, index)}
         >
@@ -124,4 +126,10 @@ export default function SearchAutocompleteDropdown(props) {
       ))}
     </SelectionList>
   );
+}
+
+// Hack for letting search bar see if an autocomplete result was focused
+export function isAutocompleteResultElement(domElement) {
+  if (!domElement) return false;
+  return [].slice.call(domElement.classList).includes(LIST_ITEM_CLASSNAME);
 }

--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -97,6 +97,10 @@ export function routeParamsReducer(state = DEFAULT_STATE, action) {
       return produce(state, (draft) => {
         draft.editingLocation = null;
       });
+    case 'search_blurred_with_unchanged_locations':
+      return produce(state, (draft) => {
+        draft.editingLocation = null;
+      });
     case 'geocoded_location_selected':
       return produce(state, (draft) => {
         draft[action.startOrEnd] = {
@@ -408,6 +412,14 @@ export function selectCurrentLocation(startOrEnd) {
 export function clearRouteParams() {
   return {
     type: 'route_params_cleared',
+  };
+}
+
+export function blurSearchWithUnchangedLocations() {
+  // When you focus the start or end input but then blur it without changing existing
+  // (geocoded, geolocated, marker dragged, etc.) locations.
+  return {
+    type: 'search_blurred_with_unchanged_locations',
   };
 }
 


### PR DESCRIPTION
This is a fix for issue #103, description copied below for reference:

>  1. Enter a start and end location and fetch routes
>  2. Tap into one of the location input boxes
>  3. Decide that you actually don't want to edit the location, but want
>  to go back to the routes already fetched
>
> This currently isn't possible. If you tap the back button in this state, it won't return you to the routes you had, but instead, clear everything out.

This implements more or less the strategy I described in a comment on that issue:

> If:
>
>   * you blur a location input,
>   * and not by focusing the other location input,
>   * nor by tapping on a location in the dropdown,
>   * and you didn't change the input you just blurred,
>   * and we already have routes,
>
> Then we should set editingLocation: null — i.e., exit the location input step and make the map visible again.
>
> On a mobile device you would do this by dismissing the virtual keyboard or tapping on a neutral area on the screen (not a button or input).
>
> This provides a pretty simple and intuitive way to cancel the change

This should make the Android bug of focusing the destination input after app switching (issue #122) less painful, because you'll be able to easily cancel the location edit.