### PR TITLE
More search results and custom icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "fs-extra": "^10.0.0",
         "history": "^5.3.0",
         "html-webpack-plugin": "^5.5.0",
-        "iconoir": "^1.0.0",
+        "iconoir": "^5.4.1",
         "identity-obj-proxy": "^3.0.0",
         "immer": "^9.0.12",
         "jest": "^27.4.3",
@@ -9425,9 +9425,9 @@
       }
     },
     "node_modules/iconoir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iconoir/-/iconoir-1.0.0.tgz",
-      "integrity": "sha512-rZ4ZMMOarUfsRrfH7h3MGIFVNrcWsThtJWpTuZOp/FYhSomaa32HhHg8WH0V3VlN7MIVK4VMD2O7jNq6jRKY3w=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/iconoir/-/iconoir-5.4.1.tgz",
+      "integrity": "sha512-5AmXmdAQRan7fbzm2iJTAY6eXw0M7mszKD1wtiuOWx8xhvZ3SXm7uE6VGvEA+OSJmiZlzlsFHk6L50EAcougRg=="
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -25082,9 +25082,9 @@
       "dev": true
     },
     "iconoir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iconoir/-/iconoir-1.0.0.tgz",
-      "integrity": "sha512-rZ4ZMMOarUfsRrfH7h3MGIFVNrcWsThtJWpTuZOp/FYhSomaa32HhHg8WH0V3VlN7MIVK4VMD2O7jNq6jRKY3w=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/iconoir/-/iconoir-5.4.1.tgz",
+      "integrity": "sha512-5AmXmdAQRan7fbzm2iJTAY6eXw0M7mszKD1wtiuOWx8xhvZ3SXm7uE6VGvEA+OSJmiZlzlsFHk6L50EAcougRg=="
     },
     "iconv-lite": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fs-extra": "^10.0.0",
     "history": "^5.3.0",
     "html-webpack-plugin": "^5.5.0",
-    "iconoir": "^1.0.0",
+    "iconoir": "^5.4.1",
     "identity-obj-proxy": "^3.0.0",
     "immer": "^9.0.12",
     "jest": "^27.4.3",

--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -10,8 +10,18 @@ import describePlace from '../lib/describePlace';
 import Icon from './Icon';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';
+import { ReactComponent as CoffeeCup } from 'iconoir/icons/coffee-cup.svg';
+import { ReactComponent as Cutlery } from 'iconoir/icons/clutery.svg';
+import { ReactComponent as Flower } from 'iconoir/icons/flower.svg';
+import { ReactComponent as GlassHalf } from 'iconoir/icons/glass-half.svg';
+import { ReactComponent as Golf } from 'iconoir/icons/golf.svg';
 import { ReactComponent as Pin } from 'iconoir/icons/pin-alt.svg';
 import { ReactComponent as Position } from 'iconoir/icons/position.svg';
+import { ReactComponent as PineTree } from 'iconoir/icons/pine-tree.svg';
+import { ReactComponent as Sandals } from 'iconoir/icons/sandals.svg';
+import { ReactComponent as StarOutline } from 'iconoir/icons/star-outline.svg';
+import { ReactComponent as Swimming } from 'iconoir/icons/swimming.svg';
+import { ReactComponent as Trekking } from 'iconoir/icons/trekking.svg';
 
 import './SearchAutocompleteDropdown.css';
 
@@ -117,7 +127,7 @@ export default function SearchAutocompleteDropdown(props) {
           onClick={handleClick.bind(null, index)}
         >
           <Icon className="SearchAutocompleteDropdown_icon">
-            <Pin />
+            {_getSvgForFeature(feature)}
           </Icon>
           <span className="SearchAutocompleteDropdown_placeDescription">
             {describePlace(feature)}
@@ -132,4 +142,55 @@ export default function SearchAutocompleteDropdown(props) {
 export function isAutocompleteResultElement(domElement) {
   if (!domElement) return false;
   return Array.from(domElement.classList).includes(LIST_ITEM_CLASSNAME);
+}
+
+function _getSvgForFeature(feature) {
+  const { osm_key: key, osm_value: value } = feature?.properties || {};
+
+  let Klass = Pin;
+
+  if (
+    (key === 'boundary' && value === 'national_park') ||
+    (key === 'leisure' && value === 'park')
+  ) {
+    // park
+    Klass = PineTree;
+  } else if (
+    (key === 'natural' && ['beach', 'shingle'].includes(value)) ||
+    (key === 'leisure' && value === 'beach_resort')
+  ) {
+    // beach
+    Klass = Sandals;
+  } else if (
+    key === 'natural' &&
+    ['peak', 'hill', 'rock', 'saddle'].includes(value)
+  ) {
+    // mountain, trail
+    Klass = Trekking;
+  } else if (key === 'leisure' && value === 'garden') {
+    Klass = Flower;
+  } else if (key === 'leisure' && value === 'golf_course') {
+    Klass = Golf;
+  } else if (
+    key === 'leisure' &&
+    ['swimming_area', 'swimming_pool', 'water_park'].includes(value)
+  ) {
+    Klass = Swimming;
+  } else if (key === 'tourism' && value === 'attraction') {
+    Klass = StarOutline;
+  } else if (key === 'amenity' && value === 'cafe') {
+    Klass = CoffeeCup;
+  } else if (
+    key === 'amenity' &&
+    ['restaurant', 'fast_food', 'food_court'].includes(value)
+  ) {
+    Klass = Cutlery;
+  } else if (
+    key === 'amenity' &&
+    ['bar', 'biergarten', 'pub'].includes(value)
+  ) {
+    Klass = GlassHalf;
+  }
+
+  return <Klass />;
 }

--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -10,15 +10,23 @@ import describePlace from '../lib/describePlace';
 import Icon from './Icon';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';
+import { ReactComponent as Building } from 'iconoir/icons/building.svg';
+import { ReactComponent as Chocolate } from 'iconoir/icons/chocolate.svg';
 import { ReactComponent as CoffeeCup } from 'iconoir/icons/coffee-cup.svg';
 import { ReactComponent as Cutlery } from 'iconoir/icons/clutery.svg';
+import { ReactComponent as Cycling } from 'iconoir/icons/cycling.svg';
 import { ReactComponent as Flower } from 'iconoir/icons/flower.svg';
 import { ReactComponent as GlassHalf } from 'iconoir/icons/glass-half.svg';
 import { ReactComponent as Golf } from 'iconoir/icons/golf.svg';
+import { ReactComponent as Gym } from 'iconoir/icons/gym.svg';
+import { ReactComponent as Home } from 'iconoir/icons/home.svg';
+import { ReactComponent as Hospital } from 'iconoir/icons/hospital.svg';
+import { ReactComponent as PharmacyCircledCross } from 'iconoir/icons/pharmacy-circled-cross.svg';
 import { ReactComponent as Pin } from 'iconoir/icons/pin-alt.svg';
-import { ReactComponent as Position } from 'iconoir/icons/position.svg';
 import { ReactComponent as PineTree } from 'iconoir/icons/pine-tree.svg';
+import { ReactComponent as Position } from 'iconoir/icons/position.svg';
 import { ReactComponent as Sandals } from 'iconoir/icons/sandals.svg';
+import { ReactComponent as Shop } from 'iconoir/icons/shop.svg';
 import { ReactComponent as StarOutline } from 'iconoir/icons/star-outline.svg';
 import { ReactComponent as Swimming } from 'iconoir/icons/swimming.svg';
 import { ReactComponent as Trekking } from 'iconoir/icons/trekking.svg';
@@ -145,13 +153,13 @@ export function isAutocompleteResultElement(domElement) {
 }
 
 function _getSvgForFeature(feature) {
-  const { osm_key: key, osm_value: value } = feature?.properties || {};
+  const { osm_key: key, osm_value: value, type } = feature?.properties || {};
 
   let Klass = Pin;
 
   if (
     (key === 'boundary' && value === 'national_park') ||
-    (key === 'leisure' && value === 'park')
+    (key === 'leisure' && ['park', 'nature_reserve'].includes(value))
   ) {
     // park
     Klass = PineTree;
@@ -162,8 +170,8 @@ function _getSvgForFeature(feature) {
     // beach
     Klass = Sandals;
   } else if (
-    key === 'natural' &&
-    ['peak', 'hill', 'rock', 'saddle'].includes(value)
+    (key === 'natural' && ['peak', 'hill', 'rock', 'saddle'].includes(value)) ||
+    (key === 'highway' && value === 'footway' && type === 'street')
   ) {
     // mountain, trail
     Klass = Trekking;
@@ -190,6 +198,27 @@ function _getSvgForFeature(feature) {
     ['bar', 'biergarten', 'pub'].includes(value)
   ) {
     Klass = GlassHalf;
+  } else if (key === 'place' && value === 'house') {
+    // note: we can't rely on type === 'house', shops have that
+    Klass = Home;
+  } else if (key === 'shop' && value === 'chocolate') {
+    Klass = Chocolate;
+  } else if (
+    (key === 'amenity' && value === 'pharmacy') ||
+    (key === 'shop' && value === 'chemist')
+  ) {
+    Klass = PharmacyCircledCross;
+  } else if (key === 'amenity' && value === 'hospital') {
+    Klass = Hospital;
+  } else if (key === 'highway' && value === 'cycleway') {
+    Klass = Cycling;
+  } else if (key === 'leisure' && value === 'fitness_centre') {
+    Klass = Gym;
+  } else if (key === 'shop') {
+    // fallback for other types of shops than above
+    Klass = Shop;
+  } else if (key === 'amenity' && value === 'townhall') {
+    Klass = Building; // might not be a great fit for city halls, but best I can do
   }
 
   return <Klass />;

--- a/src/features/geocoding.js
+++ b/src/features/geocoding.js
@@ -2,7 +2,7 @@ import produce from 'immer';
 import * as BikehopperClient from '../lib/BikehopperClient';
 import delay from '../lib/delay';
 
-const GEOCODE_RESULT_LIMIT = 5;
+const GEOCODE_RESULT_LIMIT = 8;
 
 const DEFAULT_STATE = {
   // maps location strings to geocoded results.


### PR DESCRIPTION
This is inspired by and partially mitigates issue #192, where a geocoding search for "Lands End" produced mysterious and questionable results.

I don't consider the issue to be solved by this but it helps somewhat by giving more results and a visual indication of what kind of place you're being directed to.

Example 1:

![image](https://user-images.githubusercontent.com/1730853/204690127-7d506b89-6ffb-49ab-959b-e478d739ff20.png)

Example 2:

![image](https://user-images.githubusercontent.com/1730853/204690094-ba17149c-8df1-4d29-8dad-a2ace722047b.png)

This is kind of messy and incomplete, and could be worked on more, but maybe it's worth merging in and iterating on? Open to feedback.