### PR TITLE
alert bar: hide horizontal overflow

### DIFF
--- a/src/components/AlertBar.css
+++ b/src/components/AlertBar.css
@@ -42,4 +42,5 @@
 .AlertBar_msg {
   flex-grow: 1;
   margin: 0 10px;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
I was using the alert bar for debugging and printed a long string with a URL in it and it made the "X" go offscreen so I couldn't dismiss the alert. This prevents that from happening. Shouldn't even come up with real alerts