### PR TITLE
fix changing locations from autocomplete on iPhone

### DIFF
--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -22,6 +22,7 @@ export default function SelectionListItem(props) {
         SelectionListItem_link: true,
         [props.className]: !!props.className,
       })}
+      tabindex={0}
     >
       {props.children}
     </a>


### PR DESCRIPTION
I introduced a bug in PR #195 ("make it possible to cancel a location edit") on iPhone. The bug:

1. Get routes between two geocoded locations
2. Tap on starting location
3. Tap "Current Location"

Expected: BikeHopper geolocates you (asking permission if needed) then routes from current location to the previously entered destination

Actual: The autocomplete goes away, the previously entered start point stays the same and the previously fetched routes stay

This was happening because when you tapped an autocomplete result, Safari set the event.relatedTarget of the blur event to null, whereas I rely on relatedTarget being the <a href="..." ...> of the autocomplete result.

I'm working around this by setting a tabindex on the <a>, which causes Safari to think that it can be focused.

This is not a good accessibility fix, because you still can't tab from the starting location to the autocomplete (it tabs to the ending location first, which blanks out the autocomplete). We should follow up on making the autocomplete keyboard accessible separately. Filed #202

Fixes #199