### PR TITLE
split out Bay Area-specific constants, etc to region dir

### DIFF
--- a/src/components/DirectionsNullState.js
+++ b/src/components/DirectionsNullState.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ReactComponent as MagnifyingGlass } from 'iconoir/icons/search.svg';
 import Icon from './Icon';
+import { SUPPORTED_REGION_DISPLAY } from '../lib/region';
 
 import './DirectionsNullState.css';
 
@@ -28,8 +29,10 @@ export default function DirectionsNullState(props) {
         options for getting around without a car.
       </p>
       <p className="DirectionsNullState_para">
-        We support the <strong>San Francisco Bay Area</strong>, California. Get
-        started by entering a destination above.
+        {SUPPORTED_REGION_DISPLAY && (
+          <span>We support {SUPPORTED_REGION_DISPLAY}. </span>
+        )}
+        Get started by entering a destination above.
       </p>
       <p className="DirectionsNullState_para DirectionsNullState_wideScreenOnly">
         In this early beta, BikeHopper is{' '}

--- a/src/components/Itinerary.js
+++ b/src/components/Itinerary.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { formatTime, formatDurationBetween } from '../lib/time';
-import getAgencyNameForDisplay from '../lib/getAgencyNameForDisplay';
+import { getAgencyDisplayName } from '../lib/region';
 import Icon from './Icon';
 import ItineraryBikeLeg from './ItineraryBikeLeg';
 import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
@@ -49,7 +49,7 @@ export default function Itinerary({
       let modeForLeg = 'unknown';
       if (leg.type === 'bike2') modeForLeg = 'bike';
       else if (leg.type === 'pt')
-        modeForLeg = getAgencyNameForDisplay(leg.agency_name);
+        modeForLeg = getAgencyDisplayName(leg.agency_name);
       if (!modesArray.includes(modeForLeg)) modesArray.push(modeForLeg);
       return modesArray;
     }, [])

--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { formatTime, formatDurationBetween } from '../lib/time';
-import getAgencyNameForDisplay from '../lib/getAgencyNameForDisplay';
+import { getAgencyDisplayName } from '../lib/region';
 import BorderlessButton from './BorderlessButton';
 import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
@@ -18,7 +18,7 @@ export default function ItineraryTransitLeg({ leg, onStopClick }) {
   // TODO use the actual transit mode
   const mode = 'line';
   const icon = ItineraryHeaderIcons.BUS;
-  const agency = getAgencyNameForDisplay(leg.agency_name);
+  const agency = getAgencyDisplayName(leg.agency_name);
 
   const stopsTraveled = stops.length - 1;
   const stopsBetweenStartAndEnd = stopsTraveled - 1;

--- a/src/features/viewport.js
+++ b/src/features/viewport.js
@@ -10,14 +10,13 @@
 // around in (direct) response to the state in this reducer, only vice versa.
 
 import geoViewport from '@mapbox/geo-viewport';
-
-const BAY_AREA_BOUNDS = [-122.597652, 37.330751, -121.669687, 37.858476];
+import { DEFAULT_VIEWPORT_BOUNDS } from '../lib/region';
 
 const MAPBOX_VT_SIZE = 512;
 
 function viewportForScreen(screenDims) {
   const viewport = geoViewport.viewport(
-    BAY_AREA_BOUNDS,
+    DEFAULT_VIEWPORT_BOUNDS,
     screenDims,
     0,
     14,

--- a/src/lib/region/BayArea.js
+++ b/src/lib/region/BayArea.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+export const SUPPORTED_REGION_DISPLAY = (
+  <span>
+    the <strong>San Francisco Bay Area</strong>, California
+  </span>
+);
+
+export const DEFAULT_VIEWPORT_BOUNDS = [
+  -122.597652, 37.330751, -121.669687, 37.858476,
+];
+
+export const AGENCY_COMMON_NAMES = {
+  'AC TRANSIT': 'AC Transit',
+  'Bay Area Rapid Transit': 'BART',
+  'San Francisco Municipal Transportation Agency': 'Muni',
+};

--- a/src/lib/region/index.js
+++ b/src/lib/region/index.js
@@ -1,0 +1,16 @@
+// As I write this comment, we only actively support the Bay Area. The point of
+// this file is to centralize all region-specific assumptions made on the
+// frontend in one place, so we can more easily modularize and support more
+// regions in the future.
+
+import {
+  SUPPORTED_REGION_DISPLAY,
+  DEFAULT_VIEWPORT_BOUNDS,
+  AGENCY_COMMON_NAMES,
+} from './BayArea';
+
+export { SUPPORTED_REGION_DISPLAY, DEFAULT_VIEWPORT_BOUNDS };
+
+export function getAgencyDisplayName(gtfsAgencyName) {
+  return AGENCY_COMMON_NAMES[gtfsAgencyName] || gtfsAgencyName;
+}


### PR DESCRIPTION
I wanted to start isolating all the Bay Area-specific stuff in the frontend to get a jump on supporting other regions in the future

This puts all the Bay Area stuff in the frontend (AFAIK) into lib/region/BayArea.js and we could in the future add lib/region/DC.js, lib/region/Barcelona.js, etc. (Possibly not with this exact architecture, because I don't think we can conditionally import ES modules, but we'll cross that bridge when we come to it)