### PR TITLE
[WIP] support bike-only routes

### DIFF
--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -6,6 +6,7 @@ import {
   itineraryStepClicked,
   itineraryStepBackClicked,
 } from '../features/routes';
+import { routeTypeSelected } from '../features/routeParams';
 import describePlace from '../lib/describePlace';
 import RoutesOverview from './RoutesOverview';
 import Itinerary from './Itinerary';
@@ -21,6 +22,7 @@ export default function Routes(props) {
     legIdx,
     stepIdx,
     destinationDescription,
+    routeType,
   } = useSelector(({ routes, routeParams }) => {
     let destinationDescription = 'destination';
     if (routeParams.end && routeParams.end.point) {
@@ -37,6 +39,7 @@ export default function Routes(props) {
       legIdx: routes.viewingStep && routes.viewingStep[0],
       stepIdx: routes.viewingStep && routes.viewingStep[1],
       destinationDescription,
+      routeType: routeParams.routeType,
     };
   }, shallowEqual);
 
@@ -56,12 +59,18 @@ export default function Routes(props) {
     dispatch(itineraryStepBackClicked());
   };
 
+  const handleRouteTypeClick = (routeType) => {
+    dispatch(routeTypeSelected(routeType));
+  };
+
   if (!details) {
     return (
       <RoutesOverview
         routes={routes}
         activeRoute={activeRoute}
         onRouteClick={handleRouteClick}
+        routeType={routeType}
+        onRouteTypeClick={handleRouteTypeClick}
       />
     );
   } else if (stepIdx == null) {

--- a/src/components/RoutesOverview.css
+++ b/src/components/RoutesOverview.css
@@ -1,3 +1,8 @@
+.RoutesOverview {
+  display: flex;
+  flex-direction: column;
+}
+
 .RoutesOverview_row {
   display: flex;
   flex-direction: row;

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -16,6 +16,12 @@ export default function RoutesOverview(props) {
 
   return (
     <div className="RoutesOverview">
+      <div className="RoutesOverview_routeTypeSelectionBar">
+        <button onClick={onRouteTypeClick.bind(null, 'bike+pt')}>
+          Bike + Transit
+        </button>
+        <button onClick={onRouteTypeClick.bind(null, 'bike')}>Bike</button>
+      </div>
       <SelectionList>
         {routes.map((route, index) => (
           <SelectionListItem
@@ -53,16 +59,20 @@ export default function RoutesOverview(props) {
               </ul>
               <p className="RoutesOverview_timeEstimate">
                 {formatInterval(
-                  new Date(route.legs[route.legs.length - 1].arrival_time) -
-                    new Date(route.legs[0].departure_time),
+                  route.legs.length > 0
+                    ? new Date(route.legs[route.legs.length - 1].arrival_time) -
+                        new Date(route.legs[0].departure_time)
+                    : route.time,
                 )}
               </p>
             </div>
-            <DepartArriveTime
-              className="RoutesOverview_departArriveTime"
-              depart={route.legs[0].departure_time}
-              arrive={route.legs[route.legs.length - 1].arrival_time}
-            />
+            {route.legs.length > 0 && (
+              <DepartArriveTime
+                className="RoutesOverview_departArriveTime"
+                depart={route.legs[0].departure_time}
+                arrive={route.legs[route.legs.length - 1].arrival_time}
+              />
+            )}
           </SelectionListItem>
         ))}
       </SelectionList>

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -11,59 +11,62 @@ import { ReactComponent as NavArrowRight } from 'iconoir/icons/nav-arrow-right.s
 import './RoutesOverview.css';
 
 export default function RoutesOverview(props) {
-  const { routes, activeRoute, onRouteClick } = props;
+  const { routes, activeRoute, onRouteClick, routeType, onRouteTypeClick } =
+    props;
 
   return (
-    <SelectionList>
-      {routes.map((route, index) => (
-        <SelectionListItem
-          active={activeRoute === index}
-          onClick={onRouteClick.bind(null, index)}
-          key={route.nonce}
-        >
-          <div className="RoutesOverview_row">
-            <ul className="RoutesOverview_routeLegs">
-              {route.legs.filter(isSignificantLeg).map((leg, index) => (
-                <React.Fragment key={route.nonce + ':' + index}>
-                  {index > 0 && (
-                    <li className="RoutesOverview_legSeparator">
-                      <Icon>
-                        <NavArrowRight />
-                      </Icon>
+    <div className="RoutesOverview">
+      <SelectionList>
+        {routes.map((route, index) => (
+          <SelectionListItem
+            active={activeRoute === index}
+            onClick={onRouteClick.bind(null, index)}
+            key={route.nonce}
+          >
+            <div className="RoutesOverview_row">
+              <ul className="RoutesOverview_routeLegs">
+                {route.legs.filter(isSignificantLeg).map((leg, index) => (
+                  <React.Fragment key={route.nonce + ':' + index}>
+                    {index > 0 && (
+                      <li className="RoutesOverview_legSeparator">
+                        <Icon>
+                          <NavArrowRight />
+                        </Icon>
+                      </li>
+                    )}
+                    <li className="RoutesOverview_leg">
+                      <RouteLeg
+                        type={leg.type}
+                        routeName={leg.route_name}
+                        routeColor={leg.route_color}
+                        agencyName={leg.agency_name}
+                        duration={
+                          /* hide duration if route has only one leg */
+                          route.legs.length > 1 &&
+                          new Date(leg.arrival_time) -
+                            new Date(leg.departure_time)
+                        }
+                      />
                     </li>
-                  )}
-                  <li className="RoutesOverview_leg">
-                    <RouteLeg
-                      type={leg.type}
-                      routeName={leg.route_name}
-                      routeColor={leg.route_color}
-                      agencyName={leg.agency_name}
-                      duration={
-                        /* hide duration if route has only one leg */
-                        route.legs.length > 1 &&
-                        new Date(leg.arrival_time) -
-                          new Date(leg.departure_time)
-                      }
-                    />
-                  </li>
-                </React.Fragment>
-              ))}
-            </ul>
-            <p className="RoutesOverview_timeEstimate">
-              {formatInterval(
-                new Date(route.legs[route.legs.length - 1].arrival_time) -
-                  new Date(route.legs[0].departure_time),
-              )}
-            </p>
-          </div>
-          <DepartArriveTime
-            className="RoutesOverview_departArriveTime"
-            depart={route.legs[0].departure_time}
-            arrive={route.legs[route.legs.length - 1].arrival_time}
-          />
-        </SelectionListItem>
-      ))}
-    </SelectionList>
+                  </React.Fragment>
+                ))}
+              </ul>
+              <p className="RoutesOverview_timeEstimate">
+                {formatInterval(
+                  new Date(route.legs[route.legs.length - 1].arrival_time) -
+                    new Date(route.legs[0].departure_time),
+                )}
+              </p>
+            </div>
+            <DepartArriveTime
+              className="RoutesOverview_departArriveTime"
+              depart={route.legs[0].departure_time}
+              arrive={route.legs[route.legs.length - 1].arrival_time}
+            />
+          </SelectionListItem>
+        ))}
+      </SelectionList>
+    </div>
   );
 }
 

--- a/src/features/routes.js
+++ b/src/features/routes.js
@@ -150,7 +150,13 @@ let _routeNonce = 10000000; // For assigning a unique ID to each route fetched i
 
 const COORD_EPSILON = 1e-5;
 
-export function fetchRoute(startCoords, endCoords, arriveBy, initialTime) {
+export function fetchRoute(
+  startCoords,
+  endCoords,
+  arriveBy,
+  initialTime,
+  routeType,
+) {
   return async function fetchRouteThunk(dispatch, getState) {
     if (!startCoords || !endCoords) {
       dispatch({ type: 'route_cleared' });
@@ -185,6 +191,8 @@ export function fetchRoute(startCoords, endCoords, arriveBy, initialTime) {
         optimize: true,
         pointsEncoded: false,
         details: ['cycleway', 'road_class', 'street_name'],
+        profile: routeType === 'bike+pt' ? 'pt' : 'bike2',
+        connectingProfile: 'bike2', // always include, ignored if not pt but cant be blank
       });
     } catch (e) {
       console.error('route fetch failed:', e);

--- a/src/lib/BikehopperClient.js
+++ b/src/lib/BikehopperClient.js
@@ -69,7 +69,8 @@ export async function fetchRoute({
   )
     graphHopperPath = process.env.REACT_APP_USE_LOCAL_GRAPHHOPPER;
 
-  const url = `${graphHopperPath}/route-pt?${params}`;
+  const endpointName = profile === 'pt' ? 'route-pt' : 'route';
+  const url = `${graphHopperPath}/${endpointName}?${params}`;
   const route = await fetch(url, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },

--- a/src/lib/BikehopperClient.js
+++ b/src/lib/BikehopperClient.js
@@ -48,7 +48,7 @@ export async function fetchRoute({
     layer: 'OpenStreetMap',
     profile,
     optimize,
-    pointsEncoded,
+    points_encoded: pointsEncoded,
     'pt.earliest_departure_time': earliestDepartureTime
       ? new Date(earliestDepartureTime).toISOString()
       : new Date().toISOString(),

--- a/src/lib/geometry.js
+++ b/src/lib/geometry.js
@@ -37,8 +37,19 @@ export function routesToGeoJSON(paths) {
     const path = paths[pathIdx];
 
     // For-each leg in the path
-    for (let legIdx = 0; legIdx < path.legs.length; legIdx++) {
-      const leg = path.legs[legIdx];
+    // For bike-only routing, the path *is* the leg (sort of)
+    const legs =
+      path.legs.length >= 1
+        ? path.legs
+        : [
+            {
+              type: 'bike2',
+              geometry: path.points,
+              details: path.details,
+            },
+          ];
+    for (let legIdx = 0; legIdx < legs.length; legIdx++) {
+      const leg = legs[legIdx];
 
       // Add a LineString feature for the leg
       if (leg.type === 'pt') {
@@ -58,8 +69,8 @@ export function routesToGeoJSON(paths) {
       }
 
       // Add transition for every leg except the last one
-      if (legIdx !== path.legs.length - 1) {
-        const nextLeg = path.legs[legIdx + 1];
+      if (legIdx !== legs.length - 1) {
+        const nextLeg = legs[legIdx + 1];
         const start =
           leg.geometry.coordinates[leg.geometry.coordinates.length - 1];
         const end = nextLeg.geometry.coordinates[0];


### PR DESCRIPTION
**Not mergeable**

This was an attempt to implement #75 

However, it's useless right now because it's blocked by bikehopper/graphhopper#109. Our GraphHopper fork has broken support for returning multiple bike routes, so this is useless. It'll only give one bike route, which you could get from the combined bike/PT results anyway

Also, the format of bike-only results is annoyingly slightly different (`route.legs` is not defined, `route.legs[i].geometry` is instead called `route.points`, there's no `departure_time`, etc). I only got partway through changing code that assumes the existence of `route.legs[0]`