### PR TITLE
Don't re-geocode locations hydrated from a URL

### DIFF
--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -217,8 +217,9 @@ export function locationsSubmitted() {
       // Decide whether to use the text or location:
       let useLocation = false;
 
-      // If text WAS an address string from the geocoder, and the user explicitly blanked it
-      // out, let them blank it out. But otherwise, empty text means fall back to location.
+      // If text WAS an address string from the geocoder (or hydrated from URL), and the
+      // user explicitly blanked it out, let them blank it out. But otherwise, empty text
+      // means fall back to location.
       if (
         text === '' &&
         location &&
@@ -231,6 +232,12 @@ export function locationsSubmitted() {
         text === describePlace(location.point)
       ) {
         // Stick with geocoded location if the text is its exact description
+        useLocation = true;
+      } else if (
+        location &&
+        location.source === LocationSourceType.UrlWithString &&
+        text === location.fromInputText
+      ) {
         useLocation = true;
       }
 


### PR DESCRIPTION
Fixes #210 

Ran into this while trying to use BikeHopper in Chicago without geocoding support. My workaround via the URL was breaking when BikeHopper would re-geocode the locations and get northern California results