### PR TITLE
Don't re-geocode locations hydrated from a URL

### DIFF
--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -217,8 +217,9 @@ export function locationsSubmitted() {
       // Decide whether to use the text or location:
       let useLocation = false;
 
-      // If text WAS an address string from the geocoder, and the user explicitly blanked it
-      // out, let them blank it out. But otherwise, empty text means fall back to location.
+      // If text WAS an address string from the geocoder (or hydrated from URL), and the
+      // user explicitly blanked it out, let them blank it out. But otherwise, empty text
+      // means fall back to location.
       if (
         text === '' &&
         location &&
@@ -231,6 +232,12 @@ export function locationsSubmitted() {
         text === describePlace(location.point)
       ) {
         // Stick with geocoded location if the text is its exact description
+        useLocation = true;
+      } else if (
+        location &&
+        location.source === LocationSourceType.UrlWithString &&
+        text === location.fromInputText
+      ) {
         useLocation = true;
       }
 


### PR DESCRIPTION
Fixes #210, description of issue copied below:

1. Load a URL that has geocoded route information in it (To make it clearer, you can edit the names)

2. Swap the locations

Expected result: The locations with their associated names/points are swapped as is

Actual result: BikeHopper geocodes the location text and uses the first result

I don't have a real-life repro for where this causes a problem, but it could if the place description does not geocode to that place as the first result. It's messing me up while I'm trying to use BikeHopper in another region without geocoding support...