### PR TITLE
Show transit route_id if route_name not defined

### DIFF
--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -26,7 +26,7 @@ export default function ItineraryTransitLeg({ leg, onStopClick }) {
     <>
       <ItineraryHeader icon={icon} iconColor={leg.route_color}>
         <span>
-          Ride the {leg.route_name} {mode} ({agency})
+          Ride the {leg.route_name || leg.route_id} {mode} ({agency})
         </span>
         <span>
           {pluralizedStopCount(stopsTraveled)} &middot;{' '}

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -35,7 +35,7 @@ export default function RoutesOverview(props) {
                   <li className="RoutesOverview_leg">
                     <RouteLeg
                       type={leg.type}
-                      routeName={leg.route_name}
+                      routeName={leg.route_name || leg.route_id}
                       routeColor={leg.route_color}
                       agencyName={leg.agency_name}
                       duration={


### PR DESCRIPTION
This is a workaround for a GraphHopper bug. GraphHopper is incorrectly dropping the route_name if the GTFS (legally!) defines only a route_long_name and not a route_short_name, as CTA does for its Red Line (for instance).

So, without this, the name of the Red Line in Chicago transit instructions utilizing it is missing, and there's a blank space.

See: https://github.com/bikehopper/graphhopper/issues/110