### PR TITLE
Show correct transit type & icon (bus, tram, train, etc)

### DIFF
--- a/src/components/ItineraryHeader.js
+++ b/src/components/ItineraryHeader.js
@@ -13,6 +13,8 @@ import { ReactComponent as BusIcon } from 'iconoir/icons/bus-outline.svg';
 import { ReactComponent as TrainIcon } from 'iconoir/icons/train-outline.svg';
 import { ReactComponent as TramIcon } from 'iconoir/icons/tram.svg';
 import { ReactComponent as MetroIcon } from 'iconoir/icons/metro.svg';
+// There's no ferry icon in iconoir! Sea waves is the best I can do.
+import { ReactComponent as FerryIcon } from 'iconoir/icons/sea-waves.svg';
 import { ReactComponent as ArriveIcon } from 'iconoir/icons/triangle-flag.svg';
 import { ReactComponent as UnknownIcon } from 'iconoir/icons/question-mark-circle.svg';
 import './ItineraryHeader.css';
@@ -23,6 +25,7 @@ export const ItineraryHeaderIcons = {
   TRAM: 'tram',
   TRAIN: 'train',
   METRO: 'metro',
+  FERRY: 'ferry',
   ARRIVE: 'arrive',
   UNKNOWN: 'unknown',
 };
@@ -39,6 +42,8 @@ function getIconSVGComponent(iconType) {
       return TrainIcon;
     case ItineraryHeaderIcons.METRO:
       return MetroIcon;
+    case ItineraryHeaderIcons.FERRY:
+      return FerryIcon;
     case ItineraryHeaderIcons.ARRIVE:
       return ArriveIcon;
     default:

--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -15,9 +15,44 @@ export default function ItineraryTransitLeg({ leg, onStopClick }) {
   const departure = formatTime(leg.departure_time);
   const arrival = formatTime(leg.arrival_time);
 
-  // TODO use the actual transit mode
-  const mode = 'line';
-  const icon = ItineraryHeaderIcons.BUS;
+  let mode, icon;
+  switch (leg.route_type) {
+    case 0: // tram, streetcar, light rail
+    case 12: // monorail
+      mode = 'train'; // The more specific word 'tram' might confuse in a US context
+      icon = ItineraryHeaderIcons.TRAM;
+      break;
+    case 1: // subway, metro
+      mode = 'train';
+      icon = ItineraryHeaderIcons.METRO;
+      break;
+    case 2: // rail (intercity, long distance)
+      mode = 'train';
+      icon = ItineraryHeaderIcons.TRAIN;
+      break;
+    case 3: // bus
+    case 11: // trolleybus
+      mode = 'bus';
+      icon = ItineraryHeaderIcons.BUS;
+      break;
+    case 4: // ferry
+      mode = 'ferry';
+      icon = ItineraryHeaderIcons.FERRY;
+      break;
+    case 5: // cable tram
+    case 6: // aerial lift, suspended cable car
+      mode = 'cable car';
+      icon = ItineraryHeaderIcons.TRAM;
+      break;
+    case 7: // funicular
+      mode = 'funicular';
+      icon = ItineraryHeaderIcons.TRAM;
+      break;
+    default:
+      mode = 'line';
+      icon = ItineraryHeaderIcons.BUS;
+  }
+
   const agency = getAgencyDisplayName(leg.agency_name);
 
   const stopsTraveled = stops.length - 1;


### PR DESCRIPTION
Up until now we have always shown a bus icon for every transit leg, even if it is BART, Muni light rail, a ferry, etc., and we've used the generic word "line" ("Ride the N line").

The route type is actually provided for us in GTFS though. See the spec: https://gtfs.org/schedule/reference/#routestxt

But GraphHopper hasn't been patching route_type through in its responses. That will be fixed by
https://github.com/bikehopper/graphhopper/pull/111

This commit uses the route_type, if present, to display the correct icon and a more specific noun ("Ride the N train"). When this and the above router change are both merged and deployed, this will fix #206.