### PR TITLE
mode icon in route summary

### DIFF
--- a/src/components/Itinerary.js
+++ b/src/components/Itinerary.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import { ModeIcons } from '../lib/modeDescriptions';
 import { formatTime, formatDurationBetween } from '../lib/time';
 import { getAgencyDisplayName } from '../lib/region';
 import Icon from './Icon';
 import ItineraryBikeLeg from './ItineraryBikeLeg';
-import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
+import ItineraryHeader from './ItineraryHeader';
 import ItineraryTransitLeg from './ItineraryTransitLeg';
 
 import { ReactComponent as NavLeftArrow } from 'iconoir/icons/nav-arrow-left.svg';
@@ -74,7 +75,7 @@ export default function Itinerary({
       </div>
       <div className="Itinerary_timeline">
         {renderedLegs}
-        <ItineraryHeader icon={ItineraryHeaderIcons.ARRIVE} iconColor="#ea526f">
+        <ItineraryHeader icon={ModeIcons.ARRIVE} iconColor="#ea526f">
           Arrive at destination
         </ItineraryHeader>
       </div>

--- a/src/components/ItineraryBikeLeg.js
+++ b/src/components/ItineraryBikeLeg.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import formatDistance from '../lib/formatDistance';
 import { describeBikeInfra } from '../lib/geometry';
+import { ModeIcons } from '../lib/modeDescriptions';
 import { formatDurationBetween } from '../lib/time';
 import InstructionSigns from '../lib/InstructionSigns';
 import ItineraryBikeStep from './ItineraryBikeStep';
-import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
+import ItineraryHeader from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
 import ItinerarySpacer from './ItinerarySpacer';
 
@@ -26,7 +27,7 @@ export default function ItineraryBikeLeg({ leg, legDestination, onStepClick }) {
 
   return (
     <>
-      <ItineraryHeader icon={ItineraryHeaderIcons.BIKE}>
+      <ItineraryHeader icon={ModeIcons.BIKE}>
         <span>Bike to {legDestination}</span>
         <span>
           {formatDistance(leg.distance)} &middot;{' '}

--- a/src/components/ItineraryHeader.js
+++ b/src/components/ItineraryHeader.js
@@ -5,63 +5,24 @@ import {
   DEFAULT_PT_COLOR,
   getTextColor,
 } from '../lib/colors';
+import { ModeIcons, getSvgComponentForIcon } from '../lib/modeDescriptions';
 import Icon from './Icon';
 import ItineraryRow from './ItineraryRow';
 
-import { ReactComponent as BikeIcon } from 'iconoir/icons/bicycle.svg';
-import { ReactComponent as BusIcon } from 'iconoir/icons/bus-outline.svg';
-import { ReactComponent as TrainIcon } from 'iconoir/icons/train-outline.svg';
-import { ReactComponent as TramIcon } from 'iconoir/icons/tram.svg';
-import { ReactComponent as MetroIcon } from 'iconoir/icons/metro.svg';
-// There's no ferry icon in iconoir! Sea waves is the best I can do.
-import { ReactComponent as FerryIcon } from 'iconoir/icons/sea-waves.svg';
-import { ReactComponent as ArriveIcon } from 'iconoir/icons/triangle-flag.svg';
-import { ReactComponent as UnknownIcon } from 'iconoir/icons/question-mark-circle.svg';
 import './ItineraryHeader.css';
-
-export const ItineraryHeaderIcons = {
-  BIKE: 'bike',
-  BUS: 'bus',
-  TRAM: 'tram',
-  TRAIN: 'train',
-  METRO: 'metro',
-  FERRY: 'ferry',
-  ARRIVE: 'arrive',
-  UNKNOWN: 'unknown',
-};
-
-function getIconSVGComponent(iconType) {
-  switch (iconType) {
-    case ItineraryHeaderIcons.BIKE:
-      return BikeIcon;
-    case ItineraryHeaderIcons.BUS:
-      return BusIcon;
-    case ItineraryHeaderIcons.TRAM:
-      return TramIcon;
-    case ItineraryHeaderIcons.TRAIN:
-      return TrainIcon;
-    case ItineraryHeaderIcons.METRO:
-      return MetroIcon;
-    case ItineraryHeaderIcons.FERRY:
-      return FerryIcon;
-    case ItineraryHeaderIcons.ARRIVE:
-      return ArriveIcon;
-    default:
-      return UnknownIcon;
-  }
-}
 
 export default function ItineraryHeader(props) {
   let iconColor = props.iconColor; // Actually the icon background color
   if (!iconColor) {
-    if (props.icon === ItineraryHeaderIcons.BIKE) {
+    if (props.icon === ModeIcons.BIKE) {
       iconColor = BIKEHOPPER_THEME_COLOR;
     } else {
       iconColor = DEFAULT_PT_COLOR;
     }
   }
   const iconIsWhite = getTextColor(iconColor).main === 'white';
-  const IconSVGComponent = getIconSVGComponent(props.icon);
+  const IconSVGComponent =
+    getSvgComponentForIcon(props.icon) || (() => <span />);
 
   let header, subheading;
   if (Array.isArray(props.children)) {

--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -1,8 +1,13 @@
 import * as React from 'react';
+import {
+  describeRouteType,
+  getIconForRouteType,
+  ModeIcons,
+} from '../lib/modeDescriptions';
 import { formatTime, formatDurationBetween } from '../lib/time';
 import { getAgencyDisplayName } from '../lib/region';
 import BorderlessButton from './BorderlessButton';
-import ItineraryHeader, { ItineraryHeaderIcons } from './ItineraryHeader';
+import ItineraryHeader from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
 import ItinerarySpacer from './ItinerarySpacer';
 import ItineraryStep from './ItineraryStep';
@@ -15,44 +20,8 @@ export default function ItineraryTransitLeg({ leg, onStopClick }) {
   const departure = formatTime(leg.departure_time);
   const arrival = formatTime(leg.arrival_time);
 
-  let mode, icon;
-  switch (leg.route_type) {
-    case 0: // tram, streetcar, light rail
-    case 12: // monorail
-      mode = 'train'; // The more specific word 'tram' might confuse in a US context
-      icon = ItineraryHeaderIcons.TRAM;
-      break;
-    case 1: // subway, metro
-      mode = 'train';
-      icon = ItineraryHeaderIcons.METRO;
-      break;
-    case 2: // rail (intercity, long distance)
-      mode = 'train';
-      icon = ItineraryHeaderIcons.TRAIN;
-      break;
-    case 3: // bus
-    case 11: // trolleybus
-      mode = 'bus';
-      icon = ItineraryHeaderIcons.BUS;
-      break;
-    case 4: // ferry
-      mode = 'ferry';
-      icon = ItineraryHeaderIcons.FERRY;
-      break;
-    case 5: // cable tram
-    case 6: // aerial lift, suspended cable car
-      mode = 'cable car';
-      icon = ItineraryHeaderIcons.TRAM;
-      break;
-    case 7: // funicular
-      mode = 'funicular';
-      icon = ItineraryHeaderIcons.TRAM;
-      break;
-    default:
-      mode = 'line';
-      icon = ItineraryHeaderIcons.BUS;
-  }
-
+  const mode = describeRouteType(leg.route_type);
+  const icon = getIconForRouteType(leg.route_type) || ModeIcons.BUS;
   const agency = getAgencyDisplayName(leg.agency_name);
 
   const stopsTraveled = stops.length - 1;

--- a/src/components/RouteLeg.css
+++ b/src/components/RouteLeg.css
@@ -5,6 +5,16 @@
 }
 
 .RouteLeg_transitMode {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.RouteLeg_transitModeIcon {
+  margin-right: 4px;
+}
+
+.RouteLeg_transitModeName {
   padding: 4px;
   margin-bottom: 2px;
   font-size: 15px;

--- a/src/components/RouteLeg.js
+++ b/src/components/RouteLeg.js
@@ -1,5 +1,9 @@
 import * as React from 'react';
 import { DEFAULT_PT_COLOR, getTextColor } from '../lib/colors';
+import {
+  getIconForRouteType,
+  getSvgComponentForIcon,
+} from '../lib/modeDescriptions';
 import Icon from './Icon';
 import { ReactComponent as Bicycle } from 'iconoir/icons/bicycle.svg';
 import { formatInterval } from '../lib/time';
@@ -8,27 +12,38 @@ import './RouteLeg.css';
 
 export default function RouteLeg(props) {
   let mode = '?';
-  const ICON_SIZE = 32;
 
   if (props.type === 'bike2') {
     mode = (
       <Icon flipHorizontally={true} label="Bike">
-        <Bicycle width={ICON_SIZE} height={ICON_SIZE} />
+        <Bicycle width="32" height="32" />
       </Icon>
     );
   } else if (props.type === 'pt') {
     const bgColor = props.routeColor || DEFAULT_PT_COLOR;
     const fgColor = getTextColor(bgColor).main;
+    const TransitIcon = getSvgComponentForIcon(
+      getIconForRouteType(props.routeType),
+    );
     mode = (
-      <span
-        className="RouteLeg_transitMode"
-        style={{
-          backgroundColor: bgColor,
-          color: fgColor,
-        }}
-      >
-        {props.routeName}
-      </span>
+      <div className="RouteLeg_transitMode">
+        {TransitIcon && (
+          <TransitIcon
+            width="20"
+            height="20"
+            className="RouteLeg_transitModeIcon"
+          />
+        )}
+        <span
+          className="RouteLeg_transitModeName"
+          style={{
+            backgroundColor: bgColor,
+            color: fgColor,
+          }}
+        >
+          {props.routeName}
+        </span>
+      </div>
     );
   }
 

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -52,6 +52,7 @@ export default function RoutesOverview(props) {
                       type={leg.type}
                       routeName={leg.route_name || leg.route_id}
                       routeColor={leg.route_color}
+                      routeType={leg.route_type}
                       agencyName={leg.agency_name}
                       duration={
                         /* hide duration if route has only one leg */

--- a/src/lib/modeDescriptions.js
+++ b/src/lib/modeDescriptions.js
@@ -1,0 +1,104 @@
+import { ReactComponent as BikeIcon } from 'iconoir/icons/bicycle.svg';
+import { ReactComponent as BusIcon } from 'iconoir/icons/bus-outline.svg';
+import { ReactComponent as TrainIcon } from 'iconoir/icons/train-outline.svg';
+import { ReactComponent as TramIcon } from 'iconoir/icons/tram.svg';
+import { ReactComponent as MetroIcon } from 'iconoir/icons/metro.svg';
+// There's no ferry icon in iconoir! Sea waves is the best I can do.
+import { ReactComponent as FerryIcon } from 'iconoir/icons/sea-waves.svg';
+import { ReactComponent as ArriveIcon } from 'iconoir/icons/triangle-flag.svg';
+
+export const ModeIcons = {
+  BIKE: 'bike',
+  BUS: 'bus',
+  TRAM: 'tram',
+  TRAIN: 'train',
+  METRO: 'metro',
+  FERRY: 'ferry',
+  ARRIVE: 'arrive', // not really a mode, true
+};
+
+export function getSvgComponentForIcon(iconType) {
+  switch (iconType) {
+    case ModeIcons.BIKE:
+      return BikeIcon;
+    case ModeIcons.BUS:
+      return BusIcon;
+    case ModeIcons.TRAM:
+      return TramIcon;
+    case ModeIcons.TRAIN:
+      return TrainIcon;
+    case ModeIcons.METRO:
+      return MetroIcon;
+    case ModeIcons.FERRY:
+      return FerryIcon;
+    case ModeIcons.ARRIVE:
+      return ArriveIcon;
+    default:
+      return null;
+  }
+}
+
+const _gtfsModes = {
+  0: {
+    // tram, streetcar, light rail
+    name: 'train', // The more specific word 'tram' might confuse in a US context
+    icon: ModeIcons.TRAM,
+  },
+  12: {
+    // monorail
+    name: 'train',
+    icon: ModeIcons.TRAM,
+  },
+  1: {
+    // subway, metro
+    name: 'train',
+    icon: ModeIcons.METRO,
+  },
+  2: {
+    // rail (intercity, long distance)
+    name: 'train',
+    icon: ModeIcons.TRAIN,
+  },
+  3: {
+    // bus
+    name: 'bus',
+    icon: ModeIcons.BUS,
+  },
+  11: {
+    // trolleybus
+    name: 'bus',
+    icon: ModeIcons.BUS,
+  },
+  4: {
+    // ferry
+    name: 'ferry',
+    icon: ModeIcons.FERRY,
+  },
+  5: {
+    // cable tram
+    name: 'cable car',
+    icon: ModeIcons.TRAM,
+  },
+  6: {
+    // aerial tram, suspended cable car
+    name: 'cable car',
+    icon: ModeIcons.TRAM,
+  },
+  7: {
+    // funicular
+    name: 'funicular',
+    icon: ModeIcons.TRAM,
+  },
+  default: {
+    name: 'line',
+    icon: null,
+  },
+};
+
+export function getIconForRouteType(gtfsRouteType) {
+  return (_gtfsModes[gtfsRouteType] || _gtfsModes.default).icon;
+}
+
+export function describeRouteType(gtfsRouteType) {
+  return (_gtfsModes[gtfsRouteType] || _gtfsModes.default).name;
+}


### PR DESCRIPTION
I received feedback from my designer cousin that it's hard to tell what "Bike, 5, Bike" means. We should say in the routes overview at a glance that that means the 5 bus. And so on, train icon for BART "Red-N", etc.

An example:

![routeicons1](https://user-images.githubusercontent.com/1730853/211249215-d4eb2912-9288-4e41-8802-a4087e5cbee4.png)

An example with a ferry: (it was hard to make it use ferry, I guess this ferry is slow)

![routeicons2](https://user-images.githubusercontent.com/1730853/211249235-b9e62f67-02ee-441d-8c4e-6d45809edb1d.png)

We already have code (recently added by me, used in the itinerary) to select an icon based on the GTFS route type, so this moves that code around so it can be used twice.