### PR TITLE
Preserve scroll pos when exiting single-step view

### DIFF
--- a/src/components/Itinerary.js
+++ b/src/components/Itinerary.js
@@ -15,7 +15,10 @@ export default function Itinerary({
   destinationDescription,
   onBackClick,
   onStepClick,
+  scrollToStep,
 }) {
+  const [scrollToLegIdx, scrollToStepIdx] = scrollToStep || [];
+
   const renderedLegs = route.legs.map((leg, idx, legs) => {
     if (leg.type === 'pt') {
       return (
@@ -23,6 +26,7 @@ export default function Itinerary({
           key={idx}
           leg={leg}
           onStopClick={onStepClick.bind(null, idx)}
+          scrollTo={scrollToLegIdx === idx}
         />
       );
     } else {
@@ -37,6 +41,7 @@ export default function Itinerary({
           leg={leg}
           legDestination={legDestination}
           onStepClick={onStepClick.bind(null, idx)}
+          scrollToStep={scrollToLegIdx === idx ? scrollToStepIdx : null}
         />
       );
     }

--- a/src/components/ItineraryBikeLeg.js
+++ b/src/components/ItineraryBikeLeg.js
@@ -4,12 +4,18 @@ import { describeBikeInfra } from '../lib/geometry';
 import { ModeIcons } from '../lib/modeDescriptions';
 import { formatDurationBetween } from '../lib/time';
 import InstructionSigns from '../lib/InstructionSigns';
+import useScrollToRef from '../hooks/useScrollToRef';
 import ItineraryBikeStep from './ItineraryBikeStep';
 import ItineraryHeader from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
 import ItinerarySpacer from './ItinerarySpacer';
 
-export default function ItineraryBikeLeg({ leg, legDestination, onStepClick }) {
+export default function ItineraryBikeLeg({
+  leg,
+  legDestination,
+  onStepClick,
+  scrollToStep,
+}) {
   const instructionsWithBikeInfra = React.useMemo(() => {
     return leg.instructions.map((step) => {
       return {
@@ -24,6 +30,8 @@ export default function ItineraryBikeLeg({ leg, legDestination, onStepClick }) {
       };
     });
   }, [leg]);
+
+  const scrollToRef = useScrollToRef();
 
   return (
     <>
@@ -44,6 +52,7 @@ export default function ItineraryBikeLeg({ leg, legDestination, onStepClick }) {
                 step={step}
                 isFirstStep={stepIdx === 0}
                 onClick={onStepClick.bind(null, stepIdx)}
+                rootRef={stepIdx === scrollToStep ? scrollToRef : null}
               />,
               <ItineraryDivider
                 key={stepIdx + 'd'}

--- a/src/components/ItineraryBikeStep.js
+++ b/src/components/ItineraryBikeStep.js
@@ -10,7 +10,12 @@ import { ReactComponent as ArrowUp } from 'iconoir/icons/arrow-up.svg';
 import { ReactComponent as TriangleFlag } from 'iconoir/icons/triangle-flag.svg';
 import { ReactComponent as QuestionMarkCircle } from 'iconoir/icons/question-mark-circle.svg';
 
-export default function ItineraryBikeStep({ step, isFirstStep, onClick }) {
+export default function ItineraryBikeStep({
+  step,
+  isFirstStep,
+  onClick,
+  rootRef,
+}) {
   let IconComponent = QuestionMarkCircle;
   let verb = 'Proceed';
   let direction = null;
@@ -111,7 +116,7 @@ export default function ItineraryBikeStep({ step, isFirstStep, onClick }) {
   }
 
   return (
-    <ItineraryStep IconSVGComponent={IconComponent}>
+    <ItineraryStep IconSVGComponent={IconComponent} rootRef={rootRef}>
       <BorderlessButton onClick={onClick}>{contents}</BorderlessButton>
     </ItineraryStep>
   );

--- a/src/components/ItineraryRow.js
+++ b/src/components/ItineraryRow.js
@@ -4,7 +4,7 @@ import './ItineraryRow.css';
 
 export default function ItineraryRow(props) {
   return (
-    <div className="ItineraryRow">
+    <div className="ItineraryRow" ref={props.rootRef}>
       <div className="ItineraryRow_timeline">{props.children[0]}</div>
       <div className="ItineraryRow_content">{props.children.slice(1)}</div>
     </div>

--- a/src/components/ItineraryStep.js
+++ b/src/components/ItineraryStep.js
@@ -5,11 +5,15 @@ import ItineraryRow from './ItineraryRow';
 
 import './ItineraryStep.css';
 
-export default function ItineraryStep(props) {
-  const { IconSVGComponent, smallIcon } = props;
+export default function ItineraryStep({
+  IconSVGComponent,
+  smallIcon,
+  rootRef,
+  children,
+}) {
   const iconSize = smallIcon ? 15 : 30;
   return (
-    <ItineraryRow>
+    <ItineraryRow rootRef={rootRef}>
       <span
         className={classnames({
           ItineraryStep_iconContainer: true,
@@ -29,7 +33,7 @@ export default function ItineraryStep(props) {
           />
         </Icon>
       </span>
-      <p className="ItineraryStep_content">{props.children}</p>
+      <p className="ItineraryStep_content">{children}</p>
     </ItineraryRow>
   );
 }

--- a/src/components/ItineraryTransitLeg.css
+++ b/src/components/ItineraryTransitLeg.css
@@ -1,0 +1,6 @@
+.ItineraryTransitLeg {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}

--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -6,6 +6,7 @@ import {
 } from '../lib/modeDescriptions';
 import { formatTime, formatDurationBetween } from '../lib/time';
 import { getAgencyDisplayName } from '../lib/region';
+import useScrollToRef from '../hooks/useScrollToRef';
 import BorderlessButton from './BorderlessButton';
 import ItineraryHeader from './ItineraryHeader';
 import ItineraryDivider from './ItineraryDivider';
@@ -14,7 +15,9 @@ import ItineraryStep from './ItineraryStep';
 
 import { ReactComponent as Circle } from 'iconoir/icons/circle.svg';
 
-export default function ItineraryTransitLeg({ leg, onStopClick }) {
+import './ItineraryTransitLeg.css';
+
+export default function ItineraryTransitLeg({ leg, onStopClick, scrollTo }) {
   const { stops } = leg;
 
   const departure = formatTime(leg.departure_time);
@@ -26,8 +29,11 @@ export default function ItineraryTransitLeg({ leg, onStopClick }) {
 
   const stopsTraveled = stops.length - 1;
   const stopsBetweenStartAndEnd = stopsTraveled - 1;
+
+  const scrollToRef = useScrollToRef();
+
   return (
-    <>
+    <div className="ItineraryTransitLeg" ref={scrollTo ? scrollToRef : null}>
       <ItineraryHeader icon={icon} iconColor={leg.route_color}>
         <span>
           Ride the {leg.route_name || leg.route_id} {mode} ({agency})
@@ -61,7 +67,7 @@ export default function ItineraryTransitLeg({ leg, onStopClick }) {
       </ItineraryStep>
       <ItineraryDivider />
       <ItinerarySpacer />
-    </>
+    </div>
   );
 }
 

--- a/src/components/MapPlusOverlay.css
+++ b/src/components/MapPlusOverlay.css
@@ -28,6 +28,7 @@
   flex-grow: 1;
   flex-direction: column;
   overflow-y: scroll;
+  position: relative; /* make this the offsetParent so stuff can be scrolled into view */
 }
 
 .MapPlusOverlay_bottomPane {

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import pointInPolygon from '@turf/boolean-point-in-polygon';
+import usePrevious from '../hooks/usePrevious';
 import { TRANSIT_SERVICE_AREA } from '../lib/region';
 import {
   routeClicked,
@@ -20,8 +21,7 @@ export default function Routes(props) {
     routes,
     activeRoute,
     details,
-    legIdx,
-    stepIdx,
+    viewingStep,
     destinationDescription,
     outOfAreaStart,
     outOfAreaEnd,
@@ -49,13 +49,14 @@ export default function Routes(props) {
       routes: routes.routes,
       activeRoute: routes.activeRoute,
       details: routes.viewingDetails,
-      legIdx: routes.viewingStep && routes.viewingStep[0],
-      stepIdx: routes.viewingStep && routes.viewingStep[1],
+      viewingStep: routes.viewingStep,
       destinationDescription,
       outOfAreaStart,
       outOfAreaEnd,
     };
   }, shallowEqual);
+
+  const prevViewingStep = usePrevious(viewingStep);
 
   const handleRouteClick = (index) => {
     dispatch(routeClicked(index, 'list'));
@@ -83,16 +84,18 @@ export default function Routes(props) {
         outOfAreaEnd={outOfAreaEnd}
       />
     );
-  } else if (stepIdx == null) {
+  } else if (viewingStep == null) {
     return (
       <Itinerary
         route={routes[activeRoute]}
         onBackClick={handleBackClick}
         onStepClick={handleStepClick}
         destinationDescription={destinationDescription}
+        scrollToStep={prevViewingStep}
       />
     );
   } else {
+    const [legIdx, stepIdx] = viewingStep;
     const leg = routes[activeRoute].legs[legIdx];
 
     if (leg.type !== 'pt') {

--- a/src/hooks/useScrollToRef.js
+++ b/src/hooks/useScrollToRef.js
@@ -1,0 +1,19 @@
+import { useRef, useEffect } from 'react';
+
+// A ref that will be scrolled to when the component mounts, if populated.
+// The offsetParent must be the container in which to scroll.
+
+export default function useScrollToRef() {
+  const scrollToRef = useRef();
+
+  useEffect(() => {
+    const el = scrollToRef.current;
+    if (el) {
+      const container = el.offsetParent;
+      container.scrollTop =
+        el.offsetTop + el.clientHeight / 2 - container.clientHeight / 2;
+    }
+  }, []);
+
+  return scrollToRef;
+}


### PR DESCRIPTION
In the itinerary you can click on a transit stop ("24th St Mission station") or a specific bicycle direction ("Turn left on 24th Street") to view that step/stop in isolation.

This commit makes it so, when you then go back, the step/stop you were viewing is centered, so you don't lose your place in the overall itinerary.

Fixes #218