### PR TITLE
Friendlier geolocation error msgs

### DIFF
--- a/src/features/geolocation.js
+++ b/src/features/geolocation.js
@@ -59,11 +59,13 @@ export function geolocate() {
     } catch (e) {
       const errorCode =
         e instanceof window.GeolocationPositionError ? e.code : null;
-      let errorMsg = "Can't geolocate";
+      let errorMsg = "Can't find your current location";
       if (errorCode && 'GeolocationPositionError' in window) {
         switch (errorCode) {
           case window.GeolocationPositionError.PERMISSION_DENIED:
-            errorMsg += ': permission denied';
+            errorMsg =
+              "Your browser isn't letting BikeHopper detect your current location." +
+              ' Check your browser settings for this website.';
             break;
           case window.GeolocationPositionError.POSITION_UNAVAILABLE:
             errorMsg += ': position unavailable';


### PR DESCRIPTION
Before:

> Can't geolocate: permission denied

- Unclear who's denying the permission
- Jargon-y term "geolocate" may not be understood. Are we telling them they're not allowed to navigate to the coffee shop they typed in or whatever?

Proposed:

> Your browser isn't letting BikeHopper detect your current location. Check your browser settings for this website.

- Makes it clear where the problem lies and how to resolve
- Uses the same terminology used elsewhere in app ("current location") rather than technical jargon ("geolocate")

![2023b](https://user-images.githubusercontent.com/1730853/211436597-89ee47b9-1487-47dd-9216-f37a43bbbbae.png)

Fixes #190