### PR TITLE
Fixes to restore last viewed routes when app pages out of memory

### DIFF
--- a/src/components/BikehopperMap.js
+++ b/src/components/BikehopperMap.js
@@ -15,6 +15,7 @@ import {
 } from '../lib/geometry';
 import lngLatToCoords from '../lib/lngLatToCoords';
 import { geolocated } from '../features/geolocation';
+import { mapLoaded } from '../features/misc';
 import { locationDragged } from '../features/routeParams';
 import { routeClicked } from '../features/routes';
 import { mapMoved } from '../features/viewport';
@@ -55,6 +56,11 @@ const BikehopperMap = React.forwardRef((props, mapRef) => {
     }),
     shallowEqual,
   );
+
+  const handleMapLoad = (evt) => {
+    if (props.onMapLoad) props.onMapLoad(evt);
+    dispatch(mapLoaded());
+  };
 
   const handleRouteClick = (evt) => {
     if (evt.features?.length) {
@@ -216,7 +222,7 @@ const BikehopperMap = React.forwardRef((props, mapRef) => {
           width: '100%',
           height: '100%',
         }}
-        onLoad={props.onMapLoad}
+        onLoad={handleMapLoad}
         mapStyle="mapbox://styles/mapbox/streets-v11"
         mapboxAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
         interactiveLayerIds={[

--- a/src/features/misc.js
+++ b/src/features/misc.js
@@ -1,0 +1,3 @@
+export function mapLoaded() {
+  return { type: 'map_loaded' };
+}

--- a/src/lib/pwa.js
+++ b/src/lib/pwa.js
@@ -1,0 +1,6 @@
+export function isPWA() {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    navigator.standalone
+  );
+}


### PR DESCRIPTION
BikeHopper is supposed to save route params in the URL so it can fetch the routes you were last viewing (or, similar routes but for the current time) if the page is reloaded, or freed from memory on a phone.

This fixes 2 situations where that didn't work

- Sporadically, on desktop browsers; the feature was flaky
- When installed as a progressive web app (saved to home screen)

See the individual commit messages for details.