### PR TITLE
Use custom place icons in search bar

### DIFF
--- a/src/components/PlaceIcon.js
+++ b/src/components/PlaceIcon.js
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import Icon from './Icon';
+
+import { ReactComponent as Building } from 'iconoir/icons/building.svg';
+import { ReactComponent as Chocolate } from 'iconoir/icons/chocolate.svg';
+import { ReactComponent as CoffeeCup } from 'iconoir/icons/coffee-cup.svg';
+import { ReactComponent as Cutlery } from 'iconoir/icons/clutery.svg';
+import { ReactComponent as Cycling } from 'iconoir/icons/cycling.svg';
+import { ReactComponent as Flower } from 'iconoir/icons/flower.svg';
+import { ReactComponent as GlassHalf } from 'iconoir/icons/glass-half.svg';
+import { ReactComponent as Golf } from 'iconoir/icons/golf.svg';
+import { ReactComponent as Gym } from 'iconoir/icons/gym.svg';
+import { ReactComponent as Home } from 'iconoir/icons/home.svg';
+import { ReactComponent as Hospital } from 'iconoir/icons/hospital.svg';
+import { ReactComponent as PharmacyCrossCircle } from 'iconoir/icons/pharmacy-cross-circle.svg';
+import { ReactComponent as Pin } from 'iconoir/icons/pin-alt.svg';
+import { ReactComponent as PineTree } from 'iconoir/icons/pine-tree.svg';
+import { ReactComponent as Sandals } from 'iconoir/icons/sandals.svg';
+import { ReactComponent as Shop } from 'iconoir/icons/shop.svg';
+import { ReactComponent as StarOutline } from 'iconoir/icons/star.svg';
+import { ReactComponent as Swimming } from 'iconoir/icons/swimming.svg';
+import { ReactComponent as Trekking } from 'iconoir/icons/trekking.svg';
+
+/*
+ * An icon to represent a place (place prop = GeoJSON result hash from Photon).
+ */
+
+export default function PlaceIcon({ place, width, height, className, label }) {
+  const IconSvg = _getSvgComponentForFeature(place);
+
+  // It seems if we supply an undefined or null width and height prop, it gets
+  // interpreted as 0 and makes the icon invisible. So only pass the props if nonempty
+  // width and height were passed to us.
+  const svgElement =
+    width && height ? <IconSvg width={width} height={height} /> : <IconSvg />;
+
+  return (
+    <Icon className={className} label={label}>
+      {svgElement}
+    </Icon>
+  );
+}
+
+function _getSvgComponentForFeature(feature) {
+  const { osm_key: key, osm_value: value, type } = feature?.properties || {};
+
+  let Klass = Pin;
+
+  if (
+    (key === 'boundary' && value === 'national_park') ||
+    (key === 'leisure' && ['park', 'nature_reserve'].includes(value))
+  ) {
+    // park
+    Klass = PineTree;
+  } else if (
+    (key === 'natural' && ['beach', 'shingle'].includes(value)) ||
+    (key === 'leisure' && value === 'beach_resort')
+  ) {
+    // beach
+    Klass = Sandals;
+  } else if (
+    (key === 'natural' && ['peak', 'hill', 'rock', 'saddle'].includes(value)) ||
+    (key === 'highway' && value === 'footway' && type === 'street')
+  ) {
+    // mountain, trail
+    Klass = Trekking;
+  } else if (key === 'leisure' && value === 'garden') {
+    Klass = Flower;
+  } else if (key === 'leisure' && value === 'golf_course') {
+    Klass = Golf;
+  } else if (
+    key === 'leisure' &&
+    ['swimming_area', 'swimming_pool', 'water_park'].includes(value)
+  ) {
+    Klass = Swimming;
+  } else if (key === 'tourism' && value === 'attraction') {
+    Klass = StarOutline;
+  } else if (key === 'amenity' && value === 'cafe') {
+    Klass = CoffeeCup;
+  } else if (
+    key === 'amenity' &&
+    ['restaurant', 'fast_food', 'food_court'].includes(value)
+  ) {
+    Klass = Cutlery;
+  } else if (
+    key === 'amenity' &&
+    ['bar', 'biergarten', 'pub'].includes(value)
+  ) {
+    Klass = GlassHalf;
+  } else if (key === 'place' && value === 'house') {
+    // note: we can't rely on type === 'house', shops have that
+    Klass = Home;
+  } else if (key === 'shop' && value === 'chocolate') {
+    Klass = Chocolate;
+  } else if (
+    (key === 'amenity' && value === 'pharmacy') ||
+    (key === 'shop' && value === 'chemist')
+  ) {
+    Klass = PharmacyCrossCircle;
+  } else if (key === 'amenity' && value === 'hospital') {
+    Klass = Hospital;
+  } else if (key === 'highway' && value === 'cycleway') {
+    Klass = Cycling;
+  } else if (key === 'leisure' && value === 'fitness_centre') {
+    Klass = Gym;
+  } else if (key === 'shop') {
+    // fallback for other types of shops than above
+    Klass = Shop;
+  } else if (key === 'amenity' && value === 'townhall') {
+    Klass = Building; // might not be a great fit for city halls, but best I can do
+  }
+
+  return Klass;
+}

--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -8,28 +8,11 @@ import {
 } from '../features/routeParams';
 import describePlace from '../lib/describePlace';
 import Icon from './Icon';
+import PlaceIcon from './PlaceIcon';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';
-import { ReactComponent as Building } from 'iconoir/icons/building.svg';
-import { ReactComponent as Chocolate } from 'iconoir/icons/chocolate.svg';
-import { ReactComponent as CoffeeCup } from 'iconoir/icons/coffee-cup.svg';
-import { ReactComponent as Cutlery } from 'iconoir/icons/clutery.svg';
-import { ReactComponent as Cycling } from 'iconoir/icons/cycling.svg';
-import { ReactComponent as Flower } from 'iconoir/icons/flower.svg';
-import { ReactComponent as GlassHalf } from 'iconoir/icons/glass-half.svg';
-import { ReactComponent as Golf } from 'iconoir/icons/golf.svg';
-import { ReactComponent as Gym } from 'iconoir/icons/gym.svg';
-import { ReactComponent as Home } from 'iconoir/icons/home.svg';
-import { ReactComponent as Hospital } from 'iconoir/icons/hospital.svg';
-import { ReactComponent as PharmacyCrossCircle } from 'iconoir/icons/pharmacy-cross-circle.svg';
-import { ReactComponent as Pin } from 'iconoir/icons/pin-alt.svg';
-import { ReactComponent as PineTree } from 'iconoir/icons/pine-tree.svg';
+
 import { ReactComponent as Position } from 'iconoir/icons/position.svg';
-import { ReactComponent as Sandals } from 'iconoir/icons/sandals.svg';
-import { ReactComponent as Shop } from 'iconoir/icons/shop.svg';
-import { ReactComponent as StarOutline } from 'iconoir/icons/star.svg';
-import { ReactComponent as Swimming } from 'iconoir/icons/swimming.svg';
-import { ReactComponent as Trekking } from 'iconoir/icons/trekking.svg';
 
 import './SearchAutocompleteDropdown.css';
 
@@ -134,9 +117,10 @@ export default function SearchAutocompleteDropdown(props) {
           key={feature.properties.osm_id + ':' + feature.properties.type}
           onClick={handleClick.bind(null, index)}
         >
-          <Icon className="SearchAutocompleteDropdown_icon">
-            {_getSvgForFeature(feature)}
-          </Icon>
+          <PlaceIcon
+            className="SearchAutocompleteDropdown_icon"
+            place={feature}
+          />
           <span className="SearchAutocompleteDropdown_placeDescription">
             {describePlace(feature)}
           </span>
@@ -150,76 +134,4 @@ export default function SearchAutocompleteDropdown(props) {
 export function isAutocompleteResultElement(domElement) {
   if (!domElement) return false;
   return Array.from(domElement.classList).includes(LIST_ITEM_CLASSNAME);
-}
-
-function _getSvgForFeature(feature) {
-  const { osm_key: key, osm_value: value, type } = feature?.properties || {};
-
-  let Klass = Pin;
-
-  if (
-    (key === 'boundary' && value === 'national_park') ||
-    (key === 'leisure' && ['park', 'nature_reserve'].includes(value))
-  ) {
-    // park
-    Klass = PineTree;
-  } else if (
-    (key === 'natural' && ['beach', 'shingle'].includes(value)) ||
-    (key === 'leisure' && value === 'beach_resort')
-  ) {
-    // beach
-    Klass = Sandals;
-  } else if (
-    (key === 'natural' && ['peak', 'hill', 'rock', 'saddle'].includes(value)) ||
-    (key === 'highway' && value === 'footway' && type === 'street')
-  ) {
-    // mountain, trail
-    Klass = Trekking;
-  } else if (key === 'leisure' && value === 'garden') {
-    Klass = Flower;
-  } else if (key === 'leisure' && value === 'golf_course') {
-    Klass = Golf;
-  } else if (
-    key === 'leisure' &&
-    ['swimming_area', 'swimming_pool', 'water_park'].includes(value)
-  ) {
-    Klass = Swimming;
-  } else if (key === 'tourism' && value === 'attraction') {
-    Klass = StarOutline;
-  } else if (key === 'amenity' && value === 'cafe') {
-    Klass = CoffeeCup;
-  } else if (
-    key === 'amenity' &&
-    ['restaurant', 'fast_food', 'food_court'].includes(value)
-  ) {
-    Klass = Cutlery;
-  } else if (
-    key === 'amenity' &&
-    ['bar', 'biergarten', 'pub'].includes(value)
-  ) {
-    Klass = GlassHalf;
-  } else if (key === 'place' && value === 'house') {
-    // note: we can't rely on type === 'house', shops have that
-    Klass = Home;
-  } else if (key === 'shop' && value === 'chocolate') {
-    Klass = Chocolate;
-  } else if (
-    (key === 'amenity' && value === 'pharmacy') ||
-    (key === 'shop' && value === 'chemist')
-  ) {
-    Klass = PharmacyCrossCircle;
-  } else if (key === 'amenity' && value === 'hospital') {
-    Klass = Hospital;
-  } else if (key === 'highway' && value === 'cycleway') {
-    Klass = Cycling;
-  } else if (key === 'leisure' && value === 'fitness_centre') {
-    Klass = Gym;
-  } else if (key === 'shop') {
-    // fallback for other types of shops than above
-    Klass = Shop;
-  } else if (key === 'amenity' && value === 'townhall') {
-    Klass = Building; // might not be a great fit for city halls, but best I can do
-  }
-
-  return <Klass />;
 }

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -14,7 +14,6 @@ import {
   swapLocations,
 } from '../features/routeParams';
 import usePrevious from '../hooks/usePrevious';
-import { ReactComponent as Pin } from 'iconoir/icons/pin-alt.svg';
 import { ReactComponent as NavLeftArrow } from 'iconoir/icons/nav-arrow-left.svg';
 import { ReactComponent as SwapArrows } from 'iconoir/icons/data-transfer-both.svg';
 
@@ -166,31 +165,6 @@ export default function SearchBar(props) {
     if (evt.key === 'Enter') handleSubmit(evt);
   };
 
-  // If a feature was selected for either point, use its icon; else default to pin icon.
-  const ICON_CLASS = 'SearchBar_icon';
-  let startIcon = (
-    <Icon className={ICON_CLASS}>
-      <Pin />
-    </Icon>
-  );
-  let endIcon = startIcon;
-  if (
-    startLocation &&
-    startLocation.source === LocationSourceType.Geocoded &&
-    !startTextModified
-  ) {
-    startIcon = (
-      <PlaceIcon className={ICON_CLASS} place={startLocation.point} />
-    );
-  }
-  if (
-    endLocation &&
-    endLocation.source === LocationSourceType.Geocoded &&
-    !endTextModified
-  ) {
-    endIcon = <PlaceIcon className={ICON_CLASS} place={endLocation.point} />;
-  }
-
   return (
     <div className="SearchBar">
       <button onClick={handleBackClick} className="SearchBar_backButton">
@@ -201,7 +175,12 @@ export default function SearchBar(props) {
       <div className="SearchBar_inputs">
         <form onSubmit={handleSubmit}>
           <span className="SearchBar_inputContainer">
-            {startIcon}
+            <PlaceIcon
+              className="SearchBar_icon"
+              place={
+                startLocation && !startTextModified ? startLocation.point : null
+              }
+            />
             <input
               aria-label="Starting point"
               className="SearchBar_input"
@@ -217,7 +196,10 @@ export default function SearchBar(props) {
           </span>
           <span className="SearchBar_divider_dotted" />
           <span className="SearchBar_inputContainer">
-            {endIcon}
+            <PlaceIcon
+              className="SearchBar_icon"
+              place={endLocation && !endTextModified ? endLocation.point : null}
+            />
             <input
               aria-label="Destination"
               className="SearchBar_input"


### PR DESCRIPTION
Status quo: If we have a relevant custom icon for a feature (e.g. steaming coffee mug for a cafe, tree icon for a park), we display that icon in the autocomplete drop down instead of a pin. But we still always use the generic pin icon in the search bar itself.

This commit: Uses the custom icon, if any, in the search bar itself for geocoded features. It will be replaced with a generic pin icon if the location text is subsequently edited.

![places](https://user-images.githubusercontent.com/1730853/211958919-a14bddaf-1027-4a31-8f0d-bfbce89cfc56.png)

Limitation of this commit: If the location is hydrated from the URL (reload page or follow link), the custom icon will be lost because in that case we only have the place name and coordinates, not further details.