### PR TITLE
Simplify SelectionListItem + fix rounded borders

### DIFF
--- a/src/components/MapPlusOverlay.css
+++ b/src/components/MapPlusOverlay.css
@@ -64,6 +64,7 @@ body.isIOSChromeOrSafari .MapPlusOverlay_bottomPane {
 
 .MapPlusOverlay_bottomPane__withMapHidden {
   flex-grow: 1;
+  border-radius: 0;
 }
 
 /* The transparent section of the overlay, through which the map can

--- a/src/components/RoutesOverview.css
+++ b/src/components/RoutesOverview.css
@@ -1,3 +1,14 @@
+.RoutesOverview {
+  display: flex;
+  flex-direction: column;
+}
+
+.RoutesOverview_outOfAreaWarning {
+  /* padding and bottom border to match SelectionListItem */
+  padding: 8px 24px;
+  border-bottom: 1px solid #c4c4c4;
+}
+
 .RoutesOverview_row {
   display: flex;
   flex-direction: row;

--- a/src/components/RoutesOverview.css
+++ b/src/components/RoutesOverview.css
@@ -3,6 +3,14 @@
   flex-direction: column;
 }
 
+.RoutesOverview_list {
+  border-radius: 9px 9px 0 0;
+}
+
+.RoutesOverview_firstItem {
+  border-radius: 9px 9px 0 0;
+}
+
 .RoutesOverview_outOfAreaWarning {
   /* padding and bottom border to match SelectionListItem */
   padding: 8px 24px;

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -22,64 +22,66 @@ export default function RoutesOverview(props) {
     .join(' and ');
 
   return (
-    <SelectionList>
+    <div className="RoutesOverview">
       {outOfArea && (
-        <SelectionListItem key="outOfAreaWarning">
+        <div className="RoutesOverview_outOfAreaWarning">
           Transit options may be missing. Your {outOfArea} fall
           {outOfAreaStart && outOfAreaEnd ? '' : 's'} outside the area where
           BikeHopper has local transit data.
-        </SelectionListItem>
+        </div>
       )}
-      {routes.map((route, index) => (
-        <SelectionListItem
-          active={activeRoute === index}
-          onClick={onRouteClick.bind(null, index)}
-          key={route.nonce}
-        >
-          <div className="RoutesOverview_row">
-            <ul className="RoutesOverview_routeLegs">
-              {route.legs.filter(isSignificantLeg).map((leg, index) => (
-                <React.Fragment key={route.nonce + ':' + index}>
-                  {index > 0 && (
-                    <li className="RoutesOverview_legSeparator">
-                      <Icon>
-                        <NavArrowRight />
-                      </Icon>
+      <SelectionList>
+        {routes.map((route, index) => (
+          <SelectionListItem
+            active={activeRoute === index}
+            onClick={onRouteClick.bind(null, index)}
+            key={route.nonce}
+          >
+            <div className="RoutesOverview_row">
+              <ul className="RoutesOverview_routeLegs">
+                {route.legs.filter(isSignificantLeg).map((leg, index) => (
+                  <React.Fragment key={route.nonce + ':' + index}>
+                    {index > 0 && (
+                      <li className="RoutesOverview_legSeparator">
+                        <Icon>
+                          <NavArrowRight />
+                        </Icon>
+                      </li>
+                    )}
+                    <li className="RoutesOverview_leg">
+                      <RouteLeg
+                        type={leg.type}
+                        routeName={leg.route_name || leg.route_id}
+                        routeColor={leg.route_color}
+                        routeType={leg.route_type}
+                        agencyName={leg.agency_name}
+                        duration={
+                          /* hide duration if route has only one leg */
+                          route.legs.length > 1 &&
+                          new Date(leg.arrival_time) -
+                            new Date(leg.departure_time)
+                        }
+                      />
                     </li>
-                  )}
-                  <li className="RoutesOverview_leg">
-                    <RouteLeg
-                      type={leg.type}
-                      routeName={leg.route_name || leg.route_id}
-                      routeColor={leg.route_color}
-                      routeType={leg.route_type}
-                      agencyName={leg.agency_name}
-                      duration={
-                        /* hide duration if route has only one leg */
-                        route.legs.length > 1 &&
-                        new Date(leg.arrival_time) -
-                          new Date(leg.departure_time)
-                      }
-                    />
-                  </li>
-                </React.Fragment>
-              ))}
-            </ul>
-            <p className="RoutesOverview_timeEstimate">
-              {formatInterval(
-                new Date(route.legs[route.legs.length - 1].arrival_time) -
-                  new Date(route.legs[0].departure_time),
-              )}
-            </p>
-          </div>
-          <DepartArriveTime
-            className="RoutesOverview_departArriveTime"
-            depart={route.legs[0].departure_time}
-            arrive={route.legs[route.legs.length - 1].arrival_time}
-          />
-        </SelectionListItem>
-      ))}
-    </SelectionList>
+                  </React.Fragment>
+                ))}
+              </ul>
+              <p className="RoutesOverview_timeEstimate">
+                {formatInterval(
+                  new Date(route.legs[route.legs.length - 1].arrival_time) -
+                    new Date(route.legs[0].departure_time),
+                )}
+              </p>
+            </div>
+            <DepartArriveTime
+              className="RoutesOverview_departArriveTime"
+              depart={route.legs[0].departure_time}
+              arrive={route.legs[route.legs.length - 1].arrival_time}
+            />
+          </SelectionListItem>
+        ))}
+      </SelectionList>
+    </div>
   );
 }
 

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classnames from 'classnames';
 import { formatInterval } from '../lib/time';
 import DepartArriveTime from './DepartArriveTime';
 import Icon from './Icon';
@@ -30,12 +31,15 @@ export default function RoutesOverview(props) {
           BikeHopper has local transit data.
         </div>
       )}
-      <SelectionList>
+      <SelectionList className="RoutesOverview_list">
         {routes.map((route, index) => (
           <SelectionListItem
             active={activeRoute === index}
             onClick={onRouteClick.bind(null, index)}
             key={route.nonce}
+            className={classnames({
+              RoutesOverview_firstItem: index === 0,
+            })}
           >
             <div className="RoutesOverview_row">
               <ul className="RoutesOverview_routeLegs">

--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -117,7 +117,7 @@ export default function SearchAutocompleteDropdown(props) {
     <SelectionList className="SearchAutocompleteDropdown">
       {showCurrentLocationOption && (
         <SelectionListItem
-          className={LIST_ITEM_CLASSNAME}
+          buttonClassName={LIST_ITEM_CLASSNAME}
           onClick={handleCurrentLocationClick}
         >
           <Icon className="SearchAutocompleteDropdown_icon">
@@ -130,7 +130,7 @@ export default function SearchAutocompleteDropdown(props) {
       )}
       {dedupedFeatures.map((feature, index) => (
         <SelectionListItem
-          className={LIST_ITEM_CLASSNAME}
+          buttonClassName={LIST_ITEM_CLASSNAME}
           key={feature.properties.osm_id + ':' + feature.properties.type}
           onClick={handleClick.bind(null, index)}
         >

--- a/src/components/SelectionListItem.css
+++ b/src/components/SelectionListItem.css
@@ -5,11 +5,21 @@
   flex-direction: row;
 }
 
-.SelectionListItem_active {
+.SelectionListItem__active {
   background-color: #efefef;
 }
 
-.SelectionListItem_link {
+.SelectionListItem_button {
+  /* reset; below based on BorderlessButton, but we don't want zero padding */
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  cursor: pointer;
+  text-align: left;
+  /* end reset */
+
   padding: 8px 24px;
   flex-grow: 1;
 }

--- a/src/components/SelectionListItem.css
+++ b/src/components/SelectionListItem.css
@@ -1,16 +1,12 @@
 .SelectionListItem {
-  padding: 8px 24px;
   border-bottom: 1px solid #c4c4c4;
+  padding: 0;
+  display: flex;
+  flex-direction: row;
 }
 
 .SelectionListItem_active {
   background-color: #efefef;
-}
-
-.SelectionListItem_hasLinkChild {
-  padding: 0;
-  display: flex;
-  flex-direction: row;
 }
 
 .SelectionListItem_link {

--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -11,14 +11,15 @@ export default function SelectionListItem(props) {
       className={classnames({
         SelectionListItem: true,
         SelectionListItem__active: props.active,
+        [props.className]: true,
       })}
     >
       <button
         onClick={props.onClick}
-        className={classnames({
-          SelectionListItem_button: true,
-          [props.className]: !!props.className,
-        })}
+        className={classnames(
+          'SelectionListItem_button',
+          props.buttonClassName,
+        )}
       >
         {props.children}
       </button>

--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -3,30 +3,25 @@ import classnames from 'classnames';
 
 import './SelectionListItem.css';
 
-export default function SelectionListItem(props) {
-  const handleClick = (evt) => {
-    evt.preventDefault();
-    props.onClick(evt);
-  };
+// This is only for clickable stuff! Do not use without an onClick
 
+export default function SelectionListItem(props) {
   return (
     <li
       className={classnames({
         SelectionListItem: true,
-        SelectionListItem_active: props.active,
+        SelectionListItem__active: props.active,
       })}
     >
-      <a
-        href="#"
-        onClick={handleClick}
+      <button
+        onClick={props.onClick}
         className={classnames({
-          SelectionListItem_link: true,
+          SelectionListItem_button: true,
           [props.className]: !!props.className,
         })}
-        tabIndex={0}
       >
         {props.children}
-      </a>
+      </button>
     </li>
   );
 }

--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -4,42 +4,29 @@ import classnames from 'classnames';
 import './SelectionListItem.css';
 
 export default function SelectionListItem(props) {
-  const clickable = !!props.onClick;
-
   const handleClick = (evt) => {
     evt.preventDefault();
     props.onClick(evt);
   };
-
-  /* eslint-disable jsx-a11y/anchor-is-valid */
-  // (The fix for this rule is to make this a <button>, but then it's a huge
-  // pain to remove all the default CSS.)
-  const contents = props.onClick ? (
-    <a
-      href="#"
-      onClick={handleClick}
-      className={classnames({
-        SelectionListItem_link: true,
-        [props.className]: !!props.className,
-      })}
-      tabIndex={0}
-    >
-      {props.children}
-    </a>
-  ) : (
-    props.children
-  );
 
   return (
     <li
       className={classnames({
         SelectionListItem: true,
         SelectionListItem_active: props.active,
-        SelectionListItem_hasLinkChild: clickable,
-        [props.className]: !clickable && !!props.className,
       })}
     >
-      {contents}
+      <a
+        href="#"
+        onClick={handleClick}
+        className={classnames({
+          SelectionListItem_link: true,
+          [props.className]: !!props.className,
+        })}
+        tabIndex={0}
+      >
+        {props.children}
+      </a>
     </li>
   );
 }


### PR DESCRIPTION
This is a refactor, small a11y improvement, and small visual enhancement, motivated by work I'm doing on a different branch but reviewable on its own.

Motivation: I'm adding storage of recently used locations so you can easily find directions again to a place you just looked up. Thus, I want to add an X-out so you can delete a place you don't want showing up in that list.

This PR doesn't do that however. It:

1. Simplifies `SelectionListItem`, which was using two different versions of markup depending on whether the item was clickable or not. But it's a _selection_ list, so the items are always supposed to be clickable.
2. Makes `SelectionListItem` use a `<button>` instead of a link. This is better for a11y.
3. Removes the one non-clickable usage of `SelectionListItem`: the warning for missing transit info (#209).
4. **The only real user-visible change:** Puts rounded borders at the top of the routes overview, which matches the rounded borders on the initial screen and on the itinerary view. I just realized that the rounded borders were supposed to be there and were being inadvertently hidden.