### PR TITLE
Recent locations

### DIFF
--- a/src/components/SelectionListItem.css
+++ b/src/components/SelectionListItem.css
@@ -23,3 +23,33 @@
   padding: 8px 24px;
   flex-grow: 1;
 }
+
+.SelectionListItem_button__removable {
+  padding-right: 12px;
+}
+
+.SelectionListItem_remove {
+  /* reset; below based on BorderlessButton, but we don't want zero padding */
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  cursor: pointer;
+  text-align: left;
+  /* end reset */
+
+  /* Padding = clickable as part of the button, margin = not clickable.  Using
+   * a little bit of side padding to avoid making the tap target too small, but
+   * mostly margin, since if you tap over at the far right, you may not intend
+   * to remove the item. There's a little gap in between the button to select
+   * the item and the button to remove the item; if it's not clear whether you
+   * mean to select or remove, best do nothing.
+   */
+  padding: 8px 4px;
+  margin: 0 12px;
+}
+
+.SelectionListItem_removeIcon {
+  top: 2px;
+}

--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -1,28 +1,47 @@
 import * as React from 'react';
 import classnames from 'classnames';
+import Icon from './Icon';
+
+import { ReactComponent as CancelIcon } from 'iconoir/icons/cancel.svg';
 
 import './SelectionListItem.css';
 
-// This is only for clickable stuff! Do not use without an onClick
+// This is only for clickable stuff! Do not use without an onClick.
+// Optionally it can have an onRemoveClick in which case there will be an X-out.
 
-export default function SelectionListItem(props) {
+export default function SelectionListItem({
+  active,
+  className,
+  buttonClassName,
+  onClick,
+  children,
+  onRemoveClick,
+}) {
   return (
     <li
       className={classnames({
         SelectionListItem: true,
-        SelectionListItem__active: props.active,
-        [props.className]: true,
+        SelectionListItem__active: active,
+        [className]: true,
       })}
     >
       <button
-        onClick={props.onClick}
-        className={classnames(
-          'SelectionListItem_button',
-          props.buttonClassName,
-        )}
+        onClick={onClick}
+        className={classnames({
+          SelectionListItem_button: true,
+          SelectionListItem_button__removable: !!onRemoveClick,
+          [buttonClassName]: true,
+        })}
       >
-        {props.children}
+        {children}
       </button>
+      {onRemoveClick && (
+        <button onClick={onRemoveClick} className="SelectionListItem_remove">
+          <Icon label="Remove" className="SelectionListItem_removeIcon">
+            <CancelIcon width="20" height="20" />
+          </Icon>
+        </button>
+      )}
     </li>
   );
 }

--- a/src/features/geocoding.js
+++ b/src/features/geocoding.js
@@ -31,6 +31,17 @@ const DEFAULT_STATE = {
 
 export function geocodingReducer(state = DEFAULT_STATE, action) {
   switch (action.type) {
+    case 'hydrate_from_localstorage':
+      return produce(state, (draft) => {
+        // This happens at app start, so it should be safe to replace rather than
+        // expand the cache.
+        draft.osmCache = action.geocodingOsmCache;
+        // Call the update function to purge any that are too old
+        draft.recentlyUsed = _updateRecentlyUsed(
+          action.geocodingRecentlyUsed,
+          [],
+        );
+      });
     case 'geocode_attempted':
       return produce(state, (draft) => {
         draft.typeaheadCache['@' + action.text] = {

--- a/src/features/geocoding.js
+++ b/src/features/geocoding.js
@@ -81,6 +81,13 @@ export function geocodingReducer(state = DEFAULT_STATE, action) {
             .filter((r) => r != null),
         );
       });
+    case 'recently_used_location_removed':
+      return produce(state, (draft) => {
+        const indexToRemove = draft.recentlyUsed.findIndex(
+          (r) => r.id === action.id,
+        );
+        if (indexToRemove !== -1) draft.recentlyUsed.splice(indexToRemove, 1);
+      });
     default:
       return state;
   }
@@ -179,6 +186,13 @@ export function geocodeTypedLocation(text, key, { fromTextAutocomplete } = {}) {
       features: resultPoints,
       time: Date.now(),
     });
+  };
+}
+
+export function removeRecentlyUsedLocation(id) {
+  return {
+    type: 'recently_used_location_removed',
+    id,
   };
 }
 

--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -244,10 +244,11 @@ export function locationsSubmitted() {
       if (!useLocation) {
         text = text.trim();
 
-        let cacheEntry = getState().geocoding.cache['@' + text];
+        let geocodingState = getState().geocoding;
+        let cacheEntry = geocodingState.typeaheadCache['@' + text];
         if (cacheEntry && cacheEntry.status === 'succeeded') {
           return {
-            point: cacheEntry.features[0],
+            point: geocodingState.osmCache[cacheEntry.osmIds[0]],
             source: LocationSourceType.Geocoded,
           };
         }
@@ -257,10 +258,11 @@ export function locationsSubmitted() {
         })(dispatch, getState);
 
         // check again if geocoding succeeded (there's no direct return value)
-        cacheEntry = getState().geocoding.cache['@' + text];
+        geocodingState = getState().geocoding;
+        cacheEntry = geocodingState.typeaheadCache['@' + text];
         if (cacheEntry && cacheEntry.status === 'succeeded') {
           return {
-            point: cacheEntry.features[0],
+            point: geocodingState.osmCache[cacheEntry.osmIds[0]],
             source: LocationSourceType.Geocoded,
           };
         }

--- a/src/features/storage.js
+++ b/src/features/storage.js
@@ -1,0 +1,71 @@
+/*
+ * Middleware for syncing stuff to LocalStorage to persist across sessions, and
+ * an initialization routine to load the stuff.
+ */
+
+let _warned = false;
+
+export function storageMiddleware(store) {
+  return (next) => (action) => {
+    const before = store.getState();
+    next(action);
+    const after = store.getState();
+
+    if (after.geocoding.recentlyUsed !== before.geocoding.recentlyUsed) {
+      // Save not just the OSM IDs, but the full hashes of the recently used
+      const recentlyUsedFeatures = after.geocoding.recentlyUsed.map((r) => ({
+        ts: r.lastUsed,
+        obj: after.geocoding.osmCache[r.id],
+      }));
+      const json = JSON.stringify(recentlyUsedFeatures);
+      try {
+        localStorage.setItem('ru', json);
+      } catch (e) {
+        if (process.env.NODE_ENV !== 'production' && !_warned) {
+          console.warn("Can't save recently used:", e);
+          _warned = true;
+        }
+      }
+    }
+  };
+}
+
+// This returns an action, which should be dispatched.
+export function initFromStorage() {
+  let recentlyUsedRaw = [];
+  try {
+    const json = localStorage.getItem('ru');
+    if (json) recentlyUsedRaw = JSON.parse(json);
+  } catch (e) {
+    if (process.env.NODE_ENV !== 'production')
+      console.warn("Can't load from localstorage:", e);
+  }
+
+  const osmCache = {};
+  const recentlyUsedCooked = [];
+
+  for (const entry of recentlyUsedRaw) {
+    // Do some basic validation before using them
+    if (
+      typeof entry === 'object' &&
+      typeof entry.ts === 'number' &&
+      typeof entry.obj === 'object' &&
+      typeof entry.obj.properties === 'object' &&
+      typeof entry.obj.properties.osm_id === 'number'
+    ) {
+      osmCache[entry.obj.properties.osm_id] = entry.obj;
+      recentlyUsedCooked.push({
+        lastUsed: entry.ts,
+        id: entry.obj.properties.osm_id,
+      });
+    } else if (process.env.NODE_ENV !== 'production') {
+      console.warn('Ignoring invalid recently used entry:', entry);
+    }
+  }
+
+  return {
+    type: 'hydrate_from_localstorage',
+    geocodingOsmCache: osmCache,
+    geocodingRecentlyUsed: recentlyUsedCooked,
+  };
+}

--- a/src/lib/urlMiddleware.js
+++ b/src/lib/urlMiddleware.js
@@ -23,7 +23,8 @@ export default function routesUrlMiddleware(store) {
     const routeStateAfter = stateAfter.routes;
 
     if (!history) {
-      _initializeFromUrl(store);
+      // wait until map is loaded before initializing
+      if (action.type === 'map_loaded') _initializeFromUrl(store);
       return;
     }
 

--- a/src/store.js
+++ b/src/store.js
@@ -5,6 +5,7 @@ import { geocodingReducer } from './features/geocoding';
 import { geolocationReducer } from './features/geolocation';
 import { routeParamsReducer } from './features/routeParams';
 import { routesReducer } from './features/routes';
+import { storageMiddleware, initFromStorage } from './features/storage';
 import { viewportReducer } from './features/viewport';
 import urlMiddleware from './lib/urlMiddleware';
 
@@ -21,7 +22,11 @@ const enhancedCompose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(
   rootReducer,
-  enhancedCompose(applyMiddleware(thunkMiddleware, urlMiddleware)),
+  enhancedCompose(
+    applyMiddleware(thunkMiddleware, urlMiddleware, storageMiddleware),
+  ),
 );
+
+store.dispatch(initFromStorage());
 
 export default store;


### PR DESCRIPTION
This saves recently looked-up locations to LocalStorage. This will fix one of the biggest pain points in our app where if you back out of directions by mistake, and want to get them back, you have to start over completely.

Up to 8 locations are saved, they're saved for up to just over a week, and you can X them out to remove them.

As part of this change, the geocoding reducer caches typeahead locations differently: The typeahead cache only contains OSM IDs, while a separate cache maps OSM IDs to hashes of place properties. Also, deduping multiple Photon results with the same OSM ID now happens in the reducer, not in the autocomplete component.

Possible future work:
- When Photon gives us the same OSM ID with two different osm_key/osm_value pairs, save both (could help with classification of places)
- Clean the typeahead/OSM place cache if the app is running for a long period of time (I don't know if this would ever get to be a problem realistically)
- Explicitly save a place as "home," "work" or another label so it will always be present as a suggestion