### PR TITLE
Basic i18n support

### DIFF
--- a/compile-langs.sh
+++ b/compile-langs.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+for lang in lang/*.json; do npm run compile -- $lang --ast --out-file compiled-lang/`basename $lang`; done

--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -1,0 +1,30 @@
+{
+  "PuFtyh": [
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Welcome to BikeHopper!"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " This is a new bike navigation app that suggests ways to combine biking and transit, expanding your options for getting around without a car."
+    }
+  ],
+  "Tqzrb2": [
+    {
+      "type": 0,
+      "value": "Get directions"
+    }
+  ],
+  "vcNM7g": [
+    {
+      "type": 0,
+      "value": "Enter a destination"
+    }
+  ]
+}

--- a/compiled-lang/es.json
+++ b/compiled-lang/es.json
@@ -1,0 +1,8 @@
+{
+  "Tqzrb2": [
+    {
+      "type": 0,
+      "value": "Consiga indicaciones"
+    }
+  ]
+}

--- a/config/paths.js
+++ b/config/paths.js
@@ -60,6 +60,7 @@ module.exports = {
   appIndexJs: resolveModule(resolveApp, 'src/index'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
+  appTranslations: resolveApp('compiled-lang'),
   appTsConfig: resolveApp('tsconfig.json'),
   appJsConfig: resolveApp('jsconfig.json'),
   yarnLockFile: resolveApp('yarn.lock'),

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -307,14 +307,17 @@ module.exports = function (webpackEnv) {
         // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
         // please link the files into your node_modules/ and let module-resolution kick in.
         // Make sure your source files are compiled, as they will not be processed in any way.
-        new ModuleScopePlugin(paths.appSrc, [
-          paths.appPackageJson,
-          reactRefreshRuntimeEntry,
-          reactRefreshWebpackPluginRuntimeEntry,
-          babelRuntimeEntry,
-          babelRuntimeEntryHelpers,
-          babelRuntimeRegenerator,
-        ]),
+        new ModuleScopePlugin(
+          [paths.appSrc, paths.appTranslations],
+          [
+            paths.appPackageJson,
+            reactRefreshRuntimeEntry,
+            reactRefreshWebpackPluginRuntimeEntry,
+            babelRuntimeEntry,
+            babelRuntimeEntryHelpers,
+            babelRuntimeRegenerator,
+          ]
+        ),
       ],
     },
     module: {
@@ -405,6 +408,13 @@ module.exports = function (webpackEnv) {
                   isEnvDevelopment &&
                   shouldUseReactRefresh &&
                   require.resolve('react-refresh/babel'),
+                  [
+                    require.resolve('babel-plugin-formatjs'),
+                    {
+                      idInterpolationPattern: '[sha512:contenthash:base64:6]',
+                      ast: true,
+                    },
+                  ],
                 ].filter(Boolean),
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,13 @@
+{
+  "PuFtyh": {
+    "defaultMessage": "<strong>Welcome to BikeHopper!</strong> This is a new bike navigation app that suggests ways to combine biking and transit, expanding your options for getting around without a car."
+  },
+  "Tqzrb2": {
+    "defaultMessage": "Get directions",
+    "description": "form header"
+  },
+  "vcNM7g": {
+    "defaultMessage": "Enter a destination",
+    "description": "input placeholder"
+  }
+}

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,0 +1,6 @@
+{
+  "Tqzrb2": {
+    "defaultMessage": "Consiga indicaciones",
+    "description": "form header"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "react-dev-utils": "^12.0.0",
         "react-dom": "^18.2.0",
         "react-dropdown": "^1.10.0",
+        "react-intl": "^6.2.5",
         "react-map-gl": "^7.0.6",
         "react-redux": "^8.0.5",
         "react-refresh": "^0.14.0",
@@ -84,6 +85,8 @@
         "workbox-webpack-plugin": "^6.4.1"
       },
       "devDependencies": {
+        "@formatjs/cli": "^5.1.12",
+        "babel-plugin-formatjs": "^10.3.35",
         "csv": "^6.2.5",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-react-app": "^7.0.0",
@@ -2270,6 +2273,211 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@formatjs/cli": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-5.1.12.tgz",
+      "integrity": "sha512-JibYDuD2Fxx6WmrlYXVa3lxZ43vy3f30ZqmgwowKJx7I0nWng3td/h9X8Ra7VZC2bPkH5JwCL2l90OkfK8pUjQ==",
+      "dev": true,
+      "bin": {
+        "formatjs": "bin/formatjs"
+      },
+      "engines": {
+        "node": ">= 16.5.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.2.34"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz",
+      "integrity": "sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.7.tgz",
+      "integrity": "sha512-hPeM5LXUUjtCKPybWOUAWpv8lpja8Xz+uKprFPJcg5F2Rd+/bf1E0UUsLRpaAgOReAf5HMRtoIgv/UcyPICrTQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.14.tgz",
+      "integrity": "sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/icu-skeleton-parser": "1.3.18",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.18.tgz",
+      "integrity": "sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.6.3.tgz",
+      "integrity": "sha512-JaVZk14U/GypVfCZPevQ0KdruFkq16FXx7g398/Dm+YEx/W7sRiftbZeDy4wQ7WGryb45e763XycxD9o/vm9BA==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/fast-memoize": "1.2.7",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/intl-displaynames": "6.2.3",
+        "@formatjs/intl-listformat": "7.1.7",
+        "intl-messageformat": "10.2.5",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/intl-displaynames": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.2.3.tgz",
+      "integrity": "sha512-teB0L68MDGM8jEKQg55w7nvFjzeLHE6e3eK/04s+iuEVYYmvjjiHJKHrthKENzcJ0F6mHf/AwXrbX+1mKxT6AQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-listformat": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.1.7.tgz",
+      "integrity": "sha512-Zzf5ruPpfJnrAA2hGgf/6pMgQ3tx9oJVhpqycFDavHl3eEzrwdHddGqGdSNwhd0bB4NAFttZNQdmKDldc5iDZw==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz",
+      "integrity": "sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.11.5.tgz",
+      "integrity": "sha512-cAmvKzgPqdetAr/RsxoXYhfNhMf5tERlXzJTsQw+j6tddPwIAbihACQx6KaajyJJ4aNssiziWNmcaHtjTqrrVw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@types/json-stable-stringify": "^1.0.32",
+        "@types/node": "14 || 16 || 17",
+        "chalk": "^4.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "tslib": "^2.4.0",
+        "typescript": "^4.7"
+      },
+      "peerDependencies": {
+        "ts-jest": ">=27"
+      },
+      "peerDependenciesMeta": {
+        "ts-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -4183,6 +4391,15 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "node_modules/@types/babel__helper-plugin-utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__helper-plugin-utils/-/babel__helper-plugin-utils-7.10.0.tgz",
+      "integrity": "sha512-60YtHzhQ9HAkToHVV+TB4VLzBn9lrfgrsOjiJMtbv/c1jPdekBxaByd6DMsGBzROXWoIL6U3lEFvvbu69RkUoA==",
+      "dev": true,
+      "dependencies": {
+        "@types/babel__core": "*"
+      }
+    },
     "node_modules/@types/babel__template": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
@@ -4387,6 +4604,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "node_modules/@types/json-stable-stringify": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -5492,6 +5715,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/babel-plugin-formatjs": {
+      "version": "10.3.35",
+      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.3.35.tgz",
+      "integrity": "sha512-AGPsA9jOH68CBk2kKRlC8pFkjR9F1fFQ5+BEYc3y2+8E4j188sSlooYy8l//sO5mLISfIVuo7C0PZT61MlifKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-jsx": "7",
+        "@babel/traverse": "7",
+        "@babel/types": "^7.12.11",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/ts-transformer": "3.11.5",
+        "@types/babel__core": "^7.1.7",
+        "@types/babel__helper-plugin-utils": "^7.10.0",
+        "@types/babel__traverse": "^7.1.7",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -9661,6 +9903,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.2.5.tgz",
+      "integrity": "sha512-AievYMN6WLLHwBeCTv4aRKG+w3ZNyZtkObwgsKk3Q7GNTq8zDRvDbJSBQkb2OPeVCcAKcIXvak9FF/bRNavoww==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/fast-memoize": "1.2.7",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -12420,6 +12673,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dev": true,
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12445,6 +12710,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpointer": {
@@ -15503,6 +15777,32 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-intl": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.2.5.tgz",
+      "integrity": "sha512-nz21POTKbE0sPEuEJU4o5YTZYY7VlIYCPNJaD6D2+xKyk6Noj6DoUK0LRO9LXuQNUuQ044IZl3m6ymzZRj8XFQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/intl": "2.6.3",
+        "@formatjs/intl-displaynames": "6.2.3",
+        "@formatjs/intl-listformat": "7.1.7",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "16 || 17 || 18",
+        "hoist-non-react-statics": "^3.3.2",
+        "intl-messageformat": "10.2.5",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || 17 || 18",
+        "typescript": "^4.7"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17190,7 +17490,6 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19792,6 +20091,163 @@
         }
       }
     },
+    "@formatjs/cli": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-5.1.12.tgz",
+      "integrity": "sha512-JibYDuD2Fxx6WmrlYXVa3lxZ43vy3f30ZqmgwowKJx7I0nWng3td/h9X8Ra7VZC2bPkH5JwCL2l90OkfK8pUjQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz",
+      "integrity": "sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==",
+      "requires": {
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.7.tgz",
+      "integrity": "sha512-hPeM5LXUUjtCKPybWOUAWpv8lpja8Xz+uKprFPJcg5F2Rd+/bf1E0UUsLRpaAgOReAf5HMRtoIgv/UcyPICrTQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.14.tgz",
+      "integrity": "sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/icu-skeleton-parser": "1.3.18",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.18.tgz",
+      "integrity": "sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.6.3.tgz",
+      "integrity": "sha512-JaVZk14U/GypVfCZPevQ0KdruFkq16FXx7g398/Dm+YEx/W7sRiftbZeDy4wQ7WGryb45e763XycxD9o/vm9BA==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/fast-memoize": "1.2.7",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/intl-displaynames": "6.2.3",
+        "@formatjs/intl-listformat": "7.1.7",
+        "intl-messageformat": "10.2.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl-displaynames": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.2.3.tgz",
+      "integrity": "sha512-teB0L68MDGM8jEKQg55w7nvFjzeLHE6e3eK/04s+iuEVYYmvjjiHJKHrthKENzcJ0F6mHf/AwXrbX+1mKxT6AQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl-listformat": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.1.7.tgz",
+      "integrity": "sha512-Zzf5ruPpfJnrAA2hGgf/6pMgQ3tx9oJVhpqycFDavHl3eEzrwdHddGqGdSNwhd0bB4NAFttZNQdmKDldc5iDZw==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz",
+      "integrity": "sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/ts-transformer": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.11.5.tgz",
+      "integrity": "sha512-cAmvKzgPqdetAr/RsxoXYhfNhMf5tERlXzJTsQw+j6tddPwIAbihACQx6KaajyJJ4aNssiziWNmcaHtjTqrrVw==",
+      "dev": true,
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@types/json-stable-stringify": "^1.0.32",
+        "@types/node": "14 || 16 || 17",
+        "chalk": "^4.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "tslib": "^2.4.0",
+        "typescript": "^4.7"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -21156,6 +21612,15 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@types/babel__helper-plugin-utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__helper-plugin-utils/-/babel__helper-plugin-utils-7.10.0.tgz",
+      "integrity": "sha512-60YtHzhQ9HAkToHVV+TB4VLzBn9lrfgrsOjiJMtbv/c1jPdekBxaByd6DMsGBzROXWoIL6U3lEFvvbu69RkUoA==",
+      "dev": true,
+      "requires": {
+        "@types/babel__core": "*"
+      }
+    },
     "@types/babel__template": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
@@ -21353,6 +21818,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "@types/json-stable-stringify": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -22191,6 +22662,25 @@
             "ajv-keywords": "^5.0.0"
           }
         }
+      }
+    },
+    "babel-plugin-formatjs": {
+      "version": "10.3.35",
+      "resolved": "https://registry.npmjs.org/babel-plugin-formatjs/-/babel-plugin-formatjs-10.3.35.tgz",
+      "integrity": "sha512-AGPsA9jOH68CBk2kKRlC8pFkjR9F1fFQ5+BEYc3y2+8E4j188sSlooYy8l//sO5mLISfIVuo7C0PZT61MlifKA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-jsx": "7",
+        "@babel/traverse": "7",
+        "@babel/types": "^7.12.11",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/ts-transformer": "3.11.5",
+        "@types/babel__core": "^7.1.7",
+        "@types/babel__helper-plugin-utils": "^7.10.0",
+        "@types/babel__traverse": "^7.1.7",
+        "tslib": "^2.4.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -25257,6 +25747,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "intl-messageformat": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.2.5.tgz",
+      "integrity": "sha512-AievYMN6WLLHwBeCTv4aRKG+w3ZNyZtkObwgsKk3Q7GNTq8zDRvDbJSBQkb2OPeVCcAKcIXvak9FF/bRNavoww==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/fast-memoize": "1.2.7",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "tslib": "^2.4.0"
+      }
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -27251,6 +27752,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dev": true,
+      "requires": {
+        "jsonify": "^0.0.1"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -27269,6 +27779,12 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true
     },
     "jsonpointer": {
       "version": "5.0.1",
@@ -29329,6 +29845,23 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "react-intl": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.2.5.tgz",
+      "integrity": "sha512-nz21POTKbE0sPEuEJU4o5YTZYY7VlIYCPNJaD6D2+xKyk6Noj6DoUK0LRO9LXuQNUuQ044IZl3m6ymzZRj8XFQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/intl": "2.6.3",
+        "@formatjs/intl-displaynames": "6.2.3",
+        "@formatjs/intl-listformat": "7.1.7",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "16 || 17 || 18",
+        "hoist-non-react-statics": "^3.3.2",
+        "intl-messageformat": "10.2.5",
+        "tslib": "^2.4.0"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -30585,8 +31118,7 @@
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dev-utils": "^12.0.0",
     "react-dom": "^18.2.0",
     "react-dropdown": "^1.10.0",
+    "react-intl": "^6.2.5",
     "react-map-gl": "^7.0.6",
     "react-redux": "^8.0.5",
     "react-refresh": "^0.14.0",
@@ -82,6 +83,8 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
+    "extract": "formatjs extract 'src/**/*.js' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'",
+    "compile": "formatjs compile",
     "prepare": "husky install"
   },
   "proxy": "https://api-staging.bikehopper.org",
@@ -161,6 +164,8 @@
     ]
   },
   "devDependencies": {
+    "@formatjs/cli": "^5.1.12",
+    "babel-plugin-formatjs": "^10.3.35",
     "csv": "^6.2.5",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^7.0.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { IntlProvider } from 'react-intl';
 import AlertBar from './AlertBar';
 import DirectionsNullState from './DirectionsNullState';
 import MapPlusOverlay from './MapPlusOverlay';
@@ -13,7 +14,7 @@ import {
 
 import './App.css';
 
-function App() {
+function App(props) {
   const { hasRoutes, hasLocations, isEditingLocations } = useSelector(
     (state) => ({
       hasLocations: !!(
@@ -56,14 +57,16 @@ function App() {
   );
 
   return (
-    <div className="App">
-      <AlertBar />
-      <MapPlusOverlay
-        topContent={topBar}
-        hideMap={isEditingLocations}
-        bottomContent={bottomContent}
-      />
-    </div>
+    <IntlProvider messages={props.messages} locale="en" defaultLocale="en">
+      <div className="App">
+        <AlertBar />
+        <MapPlusOverlay
+          topContent={topBar}
+          hideMap={isEditingLocations}
+          bottomContent={bottomContent}
+        />
+      </div>
+    </IntlProvider>
   );
 }
 

--- a/src/components/DirectionsNullState.js
+++ b/src/components/DirectionsNullState.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { ReactComponent as MagnifyingGlass } from 'iconoir/icons/search.svg';
 import Icon from './Icon';
 import { SUPPORTED_REGION_DISPLAY } from '../lib/region';
@@ -6,12 +7,19 @@ import { SUPPORTED_REGION_DISPLAY } from '../lib/region';
 import './DirectionsNullState.css';
 
 export default function DirectionsNullState(props) {
+  const intl = useIntl();
+
   // The <input> rendered here is fake: its only function is to get focused and then
   // switch to a different UI that has the real input box.
 
   return (
     <div className="DirectionsNullState">
-      <h2 className="DirectionsNullState_header">Get directions</h2>
+      <h2 className="DirectionsNullState_header">
+        <FormattedMessage
+          defaultMessage="Get directions"
+          description="form header"
+        />
+      </h2>
       <span className="DirectionsNullState_inputContainer">
         <Icon className="DirectionsNullState_inputIcon">
           <MagnifyingGlass />
@@ -19,14 +27,24 @@ export default function DirectionsNullState(props) {
         <input
           aria-label="Destination"
           className="DirectionsNullState_input"
-          placeholder="Enter a destination"
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Enter a destination',
+            description: 'input placeholder',
+          })}
           onFocus={props.onInputFocus}
         />
       </span>
       <p className="DirectionsNullState_para">
-        <strong>Welcome to BikeHopper!</strong> This is a new bike navigation
-        app that suggests ways to combine biking and transit, expanding your
-        options for getting around without a car.
+        <FormattedMessage
+          defaultMessage={
+            '<strong>Welcome to BikeHopper!</strong> This is a new bike navigation' +
+            ' app that suggests ways to combine biking and transit, expanding your' +
+            ' options for getting around without a car.'
+          }
+          values={{
+            strong: (chunks) => <strong>{chunks}</strong>,
+          }}
+        />
       </p>
       <p className="DirectionsNullState_para">
         {SUPPORTED_REGION_DISPLAY && (

--- a/src/index.js
+++ b/src/index.js
@@ -9,27 +9,53 @@ import store from './store';
 
 import './index.css';
 
-const ua = Bowser.parse(navigator.userAgent);
-if (
-  ua.os.name === 'iOS' &&
-  (ua.browser.name === 'Chrome' || ua.browser.name === 'Safari')
-) {
-  document.body.className += ' isIOSChromeOrSafari';
+function loadMessages(locale) {
+  if (/^es\b/.test(locale)) {
+    // all variants of Spanish
+    return import('../compiled-lang/es.json');
+  } else {
+    // default to English
+    return import('../compiled-lang/en.json');
+  }
 }
 
-const root = createRoot(document.getElementById('root'));
+function selectLocale() {
+  // override via query params
+  const overrideLocale = new URLSearchParams(document.location.search).get(
+    'locale',
+  );
+  if (overrideLocale) return overrideLocale;
 
-root.render(
-  <React.StrictMode>
-    <Router>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </Router>
-  </React.StrictMode>,
-);
+  // browser default
+  return navigator.language;
+}
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+async function bootstrapApp() {
+  const ua = Bowser.parse(navigator.userAgent);
+  if (
+    ua.os.name === 'iOS' &&
+    (ua.browser.name === 'Chrome' || ua.browser.name === 'Safari')
+  ) {
+    document.body.className += ' isIOSChromeOrSafari';
+  }
+
+  const root = createRoot(document.getElementById('root'));
+  const messages = await loadMessages(selectLocale());
+
+  root.render(
+    <React.StrictMode>
+      <Router>
+        <Provider store={store}>
+          <App messages={messages} />
+        </Provider>
+      </Router>
+    </React.StrictMode>,
+  );
+
+  // If you want to start measuring performance in your app, pass a function
+  // to log results (for example: reportWebVitals(console.log))
+  // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+  reportWebVitals();
+}
+
+bootstrapApp();


### PR DESCRIPTION
Contains 3 translatable strings, 1 of which ("Get directions") I translated to Spanish based on Wiktionary and it may be wrong.

![image](https://user-images.githubusercontent.com/1730853/214444894-7d4a9b83-eabf-4db1-8871-d5e6a10a2eb5.png)

The translation may be tested by adding `?locale=es` to the end of the BikeHopper URL.

To extract default messages:

    npm run extract

To compile translations:

    ./compile-langs.sh

TODO:
 - add lint rules https://formatjs.io/docs/guides/develop#linter-installation
 - integrate with translation tooling https://formatjs.io/docs/getting-started/application-workflow#pipeline
 - translate more messages + numbers

Relevant to #238