### PR TITLE
Fix selecting secondary dropdown result on iOS

### DIFF
--- a/src/components/SearchAutocompleteDropdown.js
+++ b/src/components/SearchAutocompleteDropdown.js
@@ -18,6 +18,8 @@ import './SearchAutocompleteDropdown.css';
 
 const LIST_ITEM_CLASSNAME = 'SearchAutocompleteDropdown_place';
 
+let _resultMousedownTime = 0;
+
 export default function SearchAutocompleteDropdown(props) {
   const dispatch = useDispatch();
 
@@ -128,12 +130,17 @@ export default function SearchAutocompleteDropdown(props) {
     dispatch(selectCurrentLocation(startOrEnd));
   };
 
+  const handleResultMousedown = () => {
+    _resultMousedownTime = Date.now();
+  };
+
   return (
     <SelectionList className="SearchAutocompleteDropdown">
       {showCurrentLocationOption && (
         <SelectionListItem
           buttonClassName={LIST_ITEM_CLASSNAME}
           onClick={handleCurrentLocationClick}
+          onMouseDown={handleResultMousedown}
         >
           <Icon className="SearchAutocompleteDropdown_icon">
             <Position />
@@ -148,6 +155,7 @@ export default function SearchAutocompleteDropdown(props) {
           buttonClassName={LIST_ITEM_CLASSNAME}
           key={feature.properties.osm_id + ':' + feature.properties.type}
           onClick={handleClick.bind(null, index)}
+          onMouseDown={handleResultMousedown}
           onRemoveClick={
             feature.fromRecentlyUsed
               ? handleRemoveClick.bind(null, index)
@@ -171,4 +179,10 @@ export default function SearchAutocompleteDropdown(props) {
 export function isAutocompleteResultElement(domElement) {
   if (!domElement) return false;
   return Array.from(domElement.classList).includes(LIST_ITEM_CLASSNAME);
+}
+
+// Hack for letting search bar see if an autocomplete result was just tapped on
+// but the browser in question does not focus it
+export function getLastAutocompleteResultMousedownTime() {
+  return _resultMousedownTime;
 }

--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -14,6 +14,7 @@ export default function SelectionListItem({
   className,
   buttonClassName,
   onClick,
+  onMouseDown,
   children,
   onRemoveClick,
 }) {
@@ -27,6 +28,7 @@ export default function SelectionListItem({
     >
       <button
         onClick={onClick}
+        onMouseDown={onMouseDown}
         className={classnames({
           SelectionListItem_button: true,
           SelectionListItem_button__removable: !!onRemoveClick,
@@ -36,7 +38,11 @@ export default function SelectionListItem({
         {children}
       </button>
       {onRemoveClick && (
-        <button onClick={onRemoveClick} className="SelectionListItem_remove">
+        <button
+          onClick={onRemoveClick}
+          onMouseDown={onMouseDown}
+          className="SelectionListItem_remove"
+        >
           <Icon label="Remove" className="SelectionListItem_removeIcon">
             <CancelIcon width="20" height="20" />
           </Icon>


### PR DESCRIPTION
I noticed that on my iPhone, when I have routes, but I want to go back and select a different autocomplete result (or "Current Location") from one of the dropdowns, it wasn't working. It just exits the search bar.

This is apparently because my solution for #103, the longstanding issue to make it easier to cancel a location edit, never worked on mobile Safari. When editing locations and the search bar is blurred, and nothing has changed, we exit out of the whole search bar on purpose to restore the routes you were looking at. Unless, that is, the search bar was blurred by focusing an autocomplete result.

But in mobile Safari, <button>s do not receive focus, so the event.relatedTarget was null.

I've hacked around this via the insight on this Stack Overflow answer that mousedown events occur before blur events:

https://stackoverflow.com/questions/7621711/how-to-prevent-blur-running-when-clicking-a-link-in-jquery

NB: That question is about blurring an input by clicking a link -- links don't receive focus -- but on mobile Safari buttons also don't receive focus so it applies to us too.