### PR TITLE
Fix "undefined" class names

### DIFF
--- a/src/components/SelectionListItem.js
+++ b/src/components/SelectionListItem.js
@@ -22,7 +22,7 @@ export default function SelectionListItem({
       className={classnames({
         SelectionListItem: true,
         SelectionListItem__active: active,
-        [className]: true,
+        [className]: !!className,
       })}
     >
       <button
@@ -30,7 +30,7 @@ export default function SelectionListItem({
         className={classnames({
           SelectionListItem_button: true,
           SelectionListItem_button__removable: !!onRemoveClick,
-          [buttonClassName]: true,
+          [buttonClassName]: !!buttonClassName,
         })}
       >
         {children}


### PR DESCRIPTION
I noticed in the inspector that SelectionListItem buttons had the class name "undefined." No user impact, but it was goofy so here's a fix.