### PR TITLE
Always refresh current location for route fetch

### DIFF
--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -268,10 +268,9 @@ export function locationsSubmitted() {
         }
 
         return null;
-      } else if (location.point) {
-        // If we already have a point, pass through
-        return location;
       } else if (location.source === LocationSourceType.UserGeolocation) {
+        // Always geolocate anew; never use the stored point. Geolocation does its own
+        // short-term caching.
         await dispatch(geolocate());
 
         const { lng, lat } = getState().geolocation;
@@ -280,6 +279,9 @@ export function locationsSubmitted() {
           point: turf.point([lng, lat]),
           source: LocationSourceType.UserGeolocation,
         };
+      } else if (location.point) {
+        // If we already have a point, not from geolocation, pass through
+        return location;
       } else {
         console.error('expected location.point');
         return null;


### PR DESCRIPTION
Today while out and about using BikeHopper, I noticed that when I changed my plans along the way and changed my destination, the "Current Location" start point of the route provided was stale.

This looks like a bug in `locationsSubmitted`. It's always falling back to a `point` if present, which it should do for Custom points or geocoded points, but for "Current Location," we should always geolocate, relying on the browser's caching (via the `maximumAge` param and the value provided for that in `features/geolocation.js`).

With this change, any time you fetch a new route, your "Current Location" will be updated first.