### PR TITLE
Add FormatJS lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,17 @@
 {
   "extends": "react-app",
+  "plugins": ["formatjs"],
   "rules": {
-    "react/jsx-no-target-blank": "off"
+    "react/jsx-no-target-blank": "off",
+    "formatjs/enforce-default-message": "error",
+    "formatjs/enforce-description": "error",
+    "formatjs/no-complex-selectors": [
+      "error",
+      {
+        "limit": 3
+      }
+    ],
+    "formatjs/no-id": "error",
+    "formatjs/no-literal-string-in-jsx": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "csv": "^6.2.5",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-react-app": "^7.0.0",
+        "eslint-plugin-formatjs": "^4.5.0",
         "husky": "^8.0.3",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
@@ -4640,6 +4641,12 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
+    "node_modules/@types/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==",
+      "dev": true
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
@@ -7947,6 +7954,32 @@
         "@babel/plugin-transform-react-jsx": "^7.14.9",
         "eslint": "^8.1.0"
       }
+    },
+    "node_modules/eslint-plugin-formatjs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.5.0.tgz",
+      "integrity": "sha512-R1vCmEymrYLp6T1JqoWcFGg9D/E4CGmzItHPjMPkJGIZ1/+jE+/xKAn/JFWKXRoc+A0gCtG3TnBBX1iUWMWq8A==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/ts-transformer": "3.11.5",
+        "@types/eslint": "7 || 8",
+        "@types/picomatch": "^2.3.0",
+        "@typescript-eslint/typescript-estree": "^5.9.1",
+        "emoji-regex": "^10.0.0",
+        "picomatch": "^2.3.1",
+        "tslib": "^2.4.0",
+        "typescript": "^4.7"
+      },
+      "peerDependencies": {
+        "eslint": "7 || 8"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
+      "dev": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.26.0",
@@ -21854,6 +21887,12 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
+    "@types/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
@@ -24418,6 +24457,31 @@
       "requires": {
         "lodash": "^4.17.21",
         "string-natural-compare": "^3.0.1"
+      }
+    },
+    "eslint-plugin-formatjs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.5.0.tgz",
+      "integrity": "sha512-R1vCmEymrYLp6T1JqoWcFGg9D/E4CGmzItHPjMPkJGIZ1/+jE+/xKAn/JFWKXRoc+A0gCtG3TnBBX1iUWMWq8A==",
+      "dev": true,
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "2.1.14",
+        "@formatjs/ts-transformer": "3.11.5",
+        "@types/eslint": "7 || 8",
+        "@types/picomatch": "^2.3.0",
+        "@typescript-eslint/typescript-estree": "^5.9.1",
+        "emoji-regex": "^10.0.0",
+        "picomatch": "^2.3.1",
+        "tslib": "^2.4.0",
+        "typescript": "^4.7"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+          "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "csv": "^6.2.5",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^7.0.0",
+    "eslint-plugin-formatjs": "^4.5.0",
     "husky": "^8.0.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",

--- a/src/components/DirectionsNullState.js
+++ b/src/components/DirectionsNullState.js
@@ -41,6 +41,7 @@ export default function DirectionsNullState(props) {
             ' app that suggests ways to combine biking and transit, expanding your' +
             ' options for getting around without a car.'
           }
+          description="paragraph in welcome screen"
           values={{
             strong: (chunks) => <strong>{chunks}</strong>,
           }}


### PR DESCRIPTION
See: https://formatjs.io/docs/tooling/linter/

I turned on rules that seem to make sense for the default case

- Enforce defaultMessage so stuff doesn't show up blank at first
- Enforce description to provide context for translators
- Let IDs be autogenerated as FormatJS recommends
- Avoid too-complicated message variants

I didn't turn on the one banning literal strings in JSX, yet, but once every message is internationalized, we could to prevent accidentally not translating something. We would want to add exceptions for deliberately untranslated things like the BikeHopper project name.