### PR TITLE
Don't display address numbers without street names

### DIFF
--- a/src/lib/describePlace.js
+++ b/src/lib/describePlace.js
@@ -17,7 +17,7 @@ export default function describePlace(
 
   const descriptionElements = [
     name,
-    housenumber != null ? housenumber + ' ' + street : street,
+    housenumber != null && street ? housenumber + ' ' + street : street,
     city,
     postcode,
   ];


### PR DESCRIPTION
I was looking up Mountain View Cemetery and... what? It has a zip code of 5000?

![image](https://user-images.githubusercontent.com/1730853/219513583-1b463176-7a54-4083-b176-6f1e602ad8a8.png)

Turns out, on OSM it has an addr:housenumber but no addr:street.

I am fixing this on OSM for this particular POI but we shouldn't display housenumbers without streets.