### PR TITLE
Display alerts in itineraries and route overviews

### DIFF
--- a/src/components/ItineraryHeader.css
+++ b/src/components/ItineraryHeader.css
@@ -36,3 +36,28 @@
   font-size: 16px;
   margin: 8px 0;
 }
+
+.ItineraryHeader_alerts {
+  background-color: #fffbca;
+  padding: 8px;
+  margin: 0;
+  list-style-type: none;
+  border: 1px solid rgb(187, 187, 187);
+  border-radius: 4px;
+}
+
+.ItineraryHeader_alertIcon {
+  margin-right: 4px;
+}
+
+.ItineraryHeader_alertHeader {
+  font-weight: bold;
+}
+
+.ItineraryHeader_alertHeader::after {
+  content: ': ';
+}
+
+.ItineraryHeader_alert:not(:last-child) {
+  margin-bottom: 12px;
+}

--- a/src/components/ItineraryHeader.js
+++ b/src/components/ItineraryHeader.js
@@ -1,12 +1,15 @@
 import * as React from 'react';
+import { useIntl } from 'react-intl';
 import classnames from 'classnames';
 import { getTextColor } from '../lib/colors';
 import Icon from './Icon';
 import ItineraryRow from './ItineraryRow';
+import { ReactComponent as WarningTriangle } from 'iconoir/icons/warning-triangle.svg';
 
 import './ItineraryHeader.css';
 
-export default function ItineraryHeader({ children, icon, iconColor }) {
+export default function ItineraryHeader({ alerts, children, icon, iconColor }) {
+  const intl = useIntl();
   const iconIsWhite = getTextColor(iconColor).main === 'white';
 
   let header, subheading;
@@ -28,6 +31,37 @@ export default function ItineraryHeader({ children, icon, iconColor }) {
       </span>
       <h3 className="ItineraryHeader_header">{header}</h3>
       {subheading && <p className="ItineraryHeader_subheading">{subheading}</p>}
+      {alerts?.length > 0 && (
+        <ul className="ItineraryHeader_alerts">
+          {alerts.map((alert) => (
+            /* TODO: Select the alert translation based on locale, instead of always
+             * using the first one.
+             *
+             * Unfortunately, for the Bay Area, no agency seems to actually translate
+             * its alerts so it has no impact which is why I've (Scott, April 2023)
+             * de-prioritized doing this.
+             */
+            <li className="ItineraryHeader_alert">
+              <Icon
+                className="ItineraryHeader_alertIcon"
+                label={intl.formatMessage({
+                  defaultMessage: 'Alert',
+                  description:
+                    'labels a transit trip as having a service alert apply to it.',
+                })}
+              >
+                <WarningTriangle />
+              </Icon>
+              <span className="ItineraryHeader_alertHeader">
+                {alert.header_text?.translation[0]?.text}
+              </span>
+              <span className="ItineraryHeader_alertBody">
+                {alert.description_text?.translation[0]?.text}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
     </ItineraryRow>
   );
 }

--- a/src/components/ItineraryTransitLeg.js
+++ b/src/components/ItineraryTransitLeg.js
@@ -36,6 +36,7 @@ export default function ItineraryTransitLeg({ leg, onStopClick, scrollTo }) {
       <ItineraryHeader
         icon={<ModeIcon mode={leg.route_type} />}
         iconColor={leg.route_color || DEFAULT_PT_COLOR}
+        alerts={leg.alerts}
       >
         <span>
           <ItineraryTransitLegHeaderMessage

--- a/src/components/RouteLeg.css
+++ b/src/components/RouteLeg.css
@@ -10,7 +10,8 @@
   align-items: center;
 }
 
-.RouteLeg_transitModeIcon {
+.RouteLeg_transitModeIcon,
+.RouteLeg_alertIcon {
   margin-right: 4px;
   top: 0 !important; /* FIXME: why does Icon have hardcoded top 4px again? */
 }

--- a/src/components/RouteLeg.js
+++ b/src/components/RouteLeg.js
@@ -5,6 +5,7 @@ import ModeIcon from './ModeIcon';
 import TransitModes from '../lib/TransitModes';
 import Icon from './Icon';
 import { ReactComponent as Bicycle } from 'iconoir/icons/bicycle.svg';
+import { ReactComponent as WarningTriangle } from 'iconoir/icons/warning-triangle.svg';
 import { formatInterval } from '../lib/time';
 
 import './RouteLeg.css';
@@ -32,6 +33,18 @@ export default function RouteLeg(props) {
     const fgColor = getTextColor(bgColor).main;
     mode = (
       <div className="RouteLeg_transitMode">
+        {props.hasAlerts && (
+          <Icon
+            className="RouteLeg_alertIcon"
+            label={intl.formatMessage({
+              defaultMessage: 'Alert',
+              description:
+                'labels a transit trip as having a service alert apply to it.',
+            })}
+          >
+            <WarningTriangle />
+          </Icon>
+        )}
         <Icon
           className="RouteLeg_transitModeIcon"
           label={_getModeLabel(props.routeType, intl)}

--- a/src/components/RoutesOverview.js
+++ b/src/components/RoutesOverview.js
@@ -68,6 +68,7 @@ export default function RoutesOverview({
                           new Date(leg.arrival_time) -
                             new Date(leg.departure_time)
                         }
+                        hasAlerts={leg.alerts?.length > 0}
                       />
                     </li>
                   </React.Fragment>


### PR DESCRIPTION
Basic implementation of service alert display. Requires this Bikehopper-web-app pull request to be merged and deployed first, or else it won't do anything:

https://github.com/bikehopper/bikehopper-web-app/pull/17

Examples in route overview. Notice the warning triangle next to the (AC Transit) L and 76, which have alerts that apply to them:

![Screenshot from 2023-04-18 16-49-22](https://user-images.githubusercontent.com/1730853/232931263-4b0301da-3c67-458c-9af4-9a4a1c5fb804.png)

Examples in itinerary. Unfortunately AC Transit's alerts are spammy and have all three languages jammed into one string instead of being properly translated, but that's what we've got to work with. Imagine actually useful alerts appearing in this space instead:

![Screenshot from 2023-04-18 17-07-15](https://user-images.githubusercontent.com/1730853/232931267-2dfd8141-b964-4e9a-b5b4-2ac3af26cef0.png)
