### PR TITLE
Fix: Initialize datetime input properly

### DIFF
--- a/src/components/TimeBar.js
+++ b/src/components/TimeBar.js
@@ -131,7 +131,9 @@ export default function TimeBar(props) {
         type="datetime-local"
         name="datetime"
         id="datetime"
-        value={timeInputValue || ''}
+        value={
+          timeInputValue ? formatDateForDateTimeLocalInput(timeInputValue) : ''
+        }
       />
     </form>
   );
@@ -146,4 +148,24 @@ function doesBrowserFireDateTimeChangePrematurely(ua) {
     (ua.browser.name === 'Firefox' && ua.platform.type === 'desktop') ||
     (ua.browser.name === 'Chrome' && ua.platform.type === 'desktop')
   );
+}
+
+// Given a thing that can be fed into a JS Date constructor (most likely a
+// ms-since-epoch timestamp), returns a string in this format:
+//   2018-06-12T19:30
+// to plug into an <input type="datetime-local">
+function formatDateForDateTimeLocalInput(dateish) {
+  const date = new Date(dateish);
+
+  const year = date.getFullYear().toString();
+  let month = (date.getMonth() + 1).toString();
+  if (month < 10) month = '0' + month;
+  let day = date.getDate().toString();
+  if (day < 10) day = '0' + day;
+  let hour = date.getHours().toString();
+  if (hour < 10) hour = '0' + hour;
+  let min = date.getMinutes().toString();
+  if (min < 10) min = '0' + min;
+
+  return `${year}-${month}-${day}T${hour}:${min}`;
 }

--- a/src/lib/urlMiddleware.js
+++ b/src/lib/urlMiddleware.js
@@ -121,21 +121,7 @@ function _initializeFromUrl(store) {
     let initialTime = null;
 
     const possibleDatetime = Number(pathElements[5]);
-    if (!Number.isNaN(possibleDatetime)) {
-      const date = new Date(possibleDatetime);
-      // It needs to be a string in this format: 2018-06-12T19:30
-      // to plug into an <input type="datetime-local">
-      const year = date.getFullYear().toString();
-      let month = (date.getMonth() + 1).toString();
-      if (month < 10) month = '0' + month;
-      let day = date.getDate().toString();
-      if (day < 10) day = '0' + day;
-      let hour = date.getHours().toString();
-      if (hour < 10) hour = '0' + hour;
-      let min = date.getMinutes().toString();
-      if (min < 10) min = '0' + min;
-      initialTime = `${year}-${month}-${day}T${hour}:${min}`;
-    }
+    if (!Number.isNaN(possibleDatetime)) initialTime = possibleDatetime;
     if (startCoords && endCoords) {
       startCoords = startCoords.map(Number);
       endCoords = endCoords.map(Number);


### PR DESCRIPTION
Another annoyance fix.

When you switch departure from "Now" to "Depart at" or "Arrive by," the datetime input should initialize to either the current time or 2 hours from now respectively. This was broken because `<input type="datetime-local">` only accepts values in this bespoke format:

    2018-06-12T19:30

and was being passed UNIX timestamps (number of ms since epoch) instead.

I've also changed the code to always keep normal timestamps in the Redux store, and use the bespoke string format only within TimeBar.