### PR TITLE
warn when bike legs have steps

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -877,6 +877,12 @@
       "value": "Ferry"
     }
   ],
+  "ccL55O": [
+    {
+      "type": 0,
+      "value": "This route may require carrying your bike up or down steps."
+    }
+  ],
   "coeI+2": [
     {
       "type": 0,

--- a/lang/en.json
+++ b/lang/en.json
@@ -203,6 +203,10 @@
     "description": "labels a transit line as being operated by a ferry. Appears next to the name or number of the line.",
     "message": "Ferry"
   },
+  "ccL55O": {
+    "description": "warning displayed in trip itinerary. Warns you that you may have to lift your bicycle up steps, such as an outdoor staircase, to complete the trip.",
+    "message": "This route may require carrying your bike up or down steps."
+  },
   "coeI+2": {
     "description": "label for dropdown with options \"now\", \"depart at\", \"arrive by\"",
     "message": "Select time"

--- a/src/components/ItineraryBikeLeg.jsx
+++ b/src/components/ItineraryBikeLeg.jsx
@@ -41,9 +41,29 @@ export default function ItineraryBikeLeg({
   // Clear out icon's SVG width/height attributes so it can be scaled with CSS
   const bikeIcon = <BikeIcon width={null} height={null} />;
 
+  const alerts = leg.has_steps
+    ? [
+        [
+          '', // no header
+          intl.formatMessage({
+            defaultMessage:
+              'This route may require carrying your bike up or down steps.',
+            description:
+              'warning displayed in trip itinerary. ' +
+              'Warns you that you may have to lift your bicycle up steps, such as an ' +
+              'outdoor staircase, to complete the trip.',
+          }),
+        ],
+      ]
+    : [];
+
   return (
     <>
-      <ItineraryHeader icon={bikeIcon} iconColor={BIKEHOPPER_THEME_COLOR}>
+      <ItineraryHeader
+        icon={bikeIcon}
+        iconColor={BIKEHOPPER_THEME_COLOR}
+        alerts={alerts}
+      >
         <span>
           <FormattedMessage
             defaultMessage="Bike to {place}"

--- a/src/components/ItineraryHeader.jsx
+++ b/src/components/ItineraryHeader.jsx
@@ -33,14 +33,7 @@ export default function ItineraryHeader({ alerts, children, icon, iconColor }) {
       {subheading && <p className="ItineraryHeader_subheading">{subheading}</p>}
       {alerts?.length > 0 && (
         <ul className="ItineraryHeader_alerts">
-          {alerts.map((alert) => (
-            /* TODO: Select the alert translation based on locale, instead of always
-             * using the first one.
-             *
-             * Unfortunately, for the Bay Area, no agency seems to actually translate
-             * its alerts so it has no impact which is why I've (Scott, April 2023)
-             * de-prioritized doing this.
-             */
+          {alerts.map(([alertHeader, alertBody]) => (
             <li className="ItineraryHeader_alert">
               <Icon
                 className="ItineraryHeader_alertIcon"
@@ -52,12 +45,14 @@ export default function ItineraryHeader({ alerts, children, icon, iconColor }) {
               >
                 <WarningTriangle />
               </Icon>
-              <span className="ItineraryHeader_alertHeader">
-                {alert.header_text?.translation[0]?.text}
-              </span>
-              <span className="ItineraryHeader_alertBody">
-                {alert.description_text?.translation[0]?.text}
-              </span>
+              {alertHeader && (
+                <span className="ItineraryHeader_alertHeader">
+                  {alertHeader}
+                </span>
+              )}
+              {alertBody && (
+                <span className="ItineraryHeader_alertBody">{alertBody}</span>
+              )}
             </li>
           ))}
         </ul>

--- a/src/components/ItineraryTransitLeg.jsx
+++ b/src/components/ItineraryTransitLeg.jsx
@@ -31,12 +31,23 @@ export default function ItineraryTransitLeg({ leg, onStopClick, scrollTo }) {
 
   const scrollToRef = useScrollToRef();
 
+  // TODO: Select the alert translation based on locale, instead of always
+  // using the first one.
+  //
+  // Unfortunately, for the Bay Area, no agency seems to actually translate
+  // its alerts so it has no impact which is why I've (Scott, April 2023)
+  // de-prioritized doing this.
+  const alertsForHeader = leg.alerts?.map((rawAlert) => [
+    rawAlert.header_text?.translation[0]?.text,
+    rawAlert.description_text?.translation[0]?.text,
+  ]);
+
   return (
     <div className="ItineraryTransitLeg" ref={scrollTo ? scrollToRef : null}>
       <ItineraryHeader
         icon={<ModeIcon mode={leg.route_type} />}
         iconColor={leg.route_color || DEFAULT_PT_COLOR}
-        alerts={leg.alerts}
+        alerts={alertsForHeader}
       >
         <span>
           <ItineraryTransitLegHeaderMessage

--- a/src/components/RouteLeg.css
+++ b/src/components/RouteLeg.css
@@ -4,16 +4,20 @@
   align-items: center;
 }
 
-.RouteLeg_transitMode {
+.RouteLeg_mode {
   display: flex;
   flex-direction: row;
   align-items: center;
+  /* TODO: look for cleaner way to set height.
+   * This is to make the transit modes be as tall as the bike icon, which is otherwise
+   * taller (because the bike icon is displayed bigger), which messes up the alignment.
+   */
+  min-height: 36px;
 }
 
 .RouteLeg_transitModeIcon,
 .RouteLeg_alertIcon {
   margin-right: 4px;
-  top: 0 !important; /* FIXME: why does Icon have hardcoded top 4px again? */
 }
 
 .RouteLeg_transitModeName {
@@ -25,9 +29,7 @@
 
 .RouteLeg_duration {
   font-size: 12px;
-}
-
-.RouteLeg_bikeIcon {
-  position: relative;
-  top: 4px;
+  /* TODO: look for cleaner way to do this. See above comment about setting height.
+   * The big bike icon has empty space under it for some reason. */
+  margin-top: -3px;
 }

--- a/src/components/RouteLeg.jsx
+++ b/src/components/RouteLeg.jsx
@@ -15,37 +15,42 @@ export default function RouteLeg(props) {
 
   let mode = '?';
 
+  const maybeAlertIcon = props.hasAlerts ? (
+    <Icon
+      className="RouteLeg_alertIcon"
+      label={intl.formatMessage({
+        defaultMessage: 'Alert',
+        description:
+          'labels a transit trip as having a service alert apply to it.',
+      })}
+    >
+      <WarningTriangle />
+    </Icon>
+  ) : null;
+
   if (props.type === 'bike2') {
     mode = (
-      <Icon
-        className="RouteLeg_bikeIcon"
-        flipHorizontally={true}
-        label={intl.formatMessage({
-          defaultMessage: 'Bike',
-          description:
-            'alt text for bicycle icon displayed in a summary of an itinerary',
-        })}
-      >
-        <Bicycle width="32" height="32" />
-      </Icon>
+      <div className="RouteLeg_mode">
+        {maybeAlertIcon}
+        <Icon
+          className="RouteLeg_bikeIcon"
+          flipHorizontally={true}
+          label={intl.formatMessage({
+            defaultMessage: 'Bike',
+            description:
+              'alt text for bicycle icon displayed in a summary of an itinerary',
+          })}
+        >
+          <Bicycle width="32" height="32" />
+        </Icon>
+      </div>
     );
   } else if (props.type === 'pt') {
     const bgColor = props.routeColor || DEFAULT_PT_COLOR;
     const fgColor = getTextColor(bgColor).main;
     mode = (
-      <div className="RouteLeg_transitMode">
-        {props.hasAlerts && (
-          <Icon
-            className="RouteLeg_alertIcon"
-            label={intl.formatMessage({
-              defaultMessage: 'Alert',
-              description:
-                'labels a transit trip as having a service alert apply to it.',
-            })}
-          >
-            <WarningTriangle />
-          </Icon>
-        )}
+      <div className="RouteLeg_mode">
+        {maybeAlertIcon}
         <Icon
           className="RouteLeg_transitModeIcon"
           label={_getModeLabel(props.routeType, intl)}

--- a/src/components/RoutesOverview.jsx
+++ b/src/components/RoutesOverview.jsx
@@ -68,7 +68,10 @@ export default function RoutesOverview({
                           new Date(leg.arrival_time) -
                             new Date(leg.departure_time)
                         }
-                        hasAlerts={leg.alerts?.length > 0}
+                        hasAlerts={
+                          leg.alerts?.length > 0 ||
+                          (leg.type === 'bike2' && leg.has_steps)
+                        }
                       />
                     </li>
                   </React.Fragment>

--- a/src/lib/BikehopperClient.js
+++ b/src/lib/BikehopperClient.js
@@ -91,6 +91,13 @@ function parse(route) {
 
       if (leg.arrival_time)
         leg.arrival_time = DateTime.fromISO(leg.arrival_time).toJSDate();
+
+      // mark bike legs that have steps
+      if (leg.type === 'bike2') {
+        leg.has_steps = leg.details?.road_class?.some(
+          ([_start, _end, roadClass]) => roadClass === 'steps',
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Here's a quick and dirty solution for warning when routes have steps (#263). It borrows the icon we use for transit service alerts.

This also fixes alerts looking goofy if the header or body text is blank, seen in the wild in SFMTA alerts, part of issue #258.

## Screenshot 1: overview

![Screenshot from 2023-05-12 17-19-17](https://github.com/bikehopper/bikehopper-ui/assets/1730853/c18858f8-5189-432a-9b2f-3853477373a0)

## Screenshot 2: itinerary

![Screenshot from 2023-05-12 16-57-56](https://github.com/bikehopper/bikehopper-ui/assets/1730853/6d64efbc-6212-442f-998e-3f70f14fccfd)

## Screenshot 3: fix for transit service alert with no header text (#258)

![Screenshot from 2023-05-12 16-32-28](https://github.com/bikehopper/bikehopper-ui/assets/1730853/0d5e04fe-d933-4253-8d79-d0e9874383ed)

## Future work

- *Use a steps icon instead of the generic alert icon.* I [requested a steps icon](https://github.com/iconoir-icons/iconoir/issues/307) from the icon library we use, or we could also look for another compatibly-licensed icon collection that has one or draw our own.
- *Clean up the CSS, which is a bit weird.* I made it look properly aligned in Chrome and Firefox. I'll probably be restyling things using TailwindCSS pretty soon, so didn't want to spend much time fiddling with it.