### PR TITLE
fix vertical alignment of "back to routes" icon

### DIFF
--- a/src/components/Itinerary.css
+++ b/src/components/Itinerary.css
@@ -48,6 +48,8 @@
 
 .Itinerary_backIcon {
   vertical-align: middle;
+  position: relative;
+  top: 4px;
 }
 
 .Itinerary_backIcon path {


### PR DESCRIPTION
I removed this top: 4px rule from Icon itself and missed that it needed to be added back here

Broken

![image](https://github.com/bikehopper/bikehopper-ui/assets/1730853/c3646772-faf1-440e-a09f-66111c00dd4b)

Fixed

![image](https://github.com/bikehopper/bikehopper-ui/assets/1730853/315526b4-b4d2-43f7-9ba4-a8a8a7cd49ae)
