### PR TITLE
Fix long-press to select points on Android

### DIFF
--- a/src/components/MapPlusOverlay.jsx
+++ b/src/components/MapPlusOverlay.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import MoonLoader from 'react-spinners/MoonLoader';
 import useResizeObserver from '../hooks/useResizeObserver';
 import { BOTTOM_DRAWER_DEFAULT_SCROLL } from '../lib/layout';
+import { isTouchMoveSignificant } from '../lib/touch';
 import BikehopperMap from './BikehopperMap';
 import * as VisualViewportTracker from '../lib/VisualViewportTracker';
 
@@ -147,10 +148,16 @@ function MapPlusOverlay(props) {
       // "clicks," not raw touch events, to do things.
       // TODO: We might want to delay to make sure it's not a double-tap-to-zoom?
 
-      const dx = mapTouchState.lastClientX - mapTouchState.startClientX;
-      const dy = mapTouchState.lastClientY - mapTouchState.startClientY;
-      const distanceMoved = Math.sqrt(dx * dx + dy * dy);
-      if (distanceMoved > 7) return; // more of a drag than a click
+      if (
+        isTouchMoveSignificant(
+          mapTouchState.startClientX,
+          mapTouchState.startClientY,
+          mapTouchState.lastClientX,
+          mapTouchState.lastClientY,
+        )
+      ) {
+        return; // more of a drag than a click
+      }
 
       const syntheticEvent = new MouseEvent('click', {
         bubbles: true, // might click on a <span> inside of a <button>, etc

--- a/src/lib/touch.js
+++ b/src/lib/touch.js
@@ -1,0 +1,13 @@
+export function isTouchMoveSignificant(
+  firstClientX,
+  firstClientY,
+  secondClientX,
+  secondClientY,
+) {
+  // This is almost trivial, but we needed it in two places, so why not extract it and
+  // make sure the threshold is consistent?
+  const dx = secondClientX - firstClientX;
+  const dy = secondClientY - firstClientY;
+  const distanceMoved = Math.sqrt(dx * dx + dy * dy);
+  return distanceMoved > 7;
+}


### PR DESCRIPTION
Apparently Chrome for Android, unlike Safari for iPhone, fires a series of touchmove events even when you've only moved your finger an imperceptible amount, so we were failing to detect any long-press events.

We already have code in the map overlay to see if a touch move is far enough not to consider it a "click," so I factored this out and reused it.

Not yet actually tested on Android. @abhumbla, can you check this out and see if it works for you?

Also, I discovered a bug where (on iPhone Safari) the context menu could trigger while dragging a marker around, so fixed that too.