### PR TITLE
Show total elevation gain/loss for routes if available

### DIFF
--- a/src/components/RoutesOverview.css
+++ b/src/components/RoutesOverview.css
@@ -60,6 +60,10 @@
   font-size: 14px;
 }
 
+.RoutesOverview_ascendDescend:before {
+  content: ' \00B7\00A0';
+}
+
 .RoutesOverview_acknowledgement {
   font-size: 14px;
   margin: 24px;

--- a/src/components/RoutesOverview.css
+++ b/src/components/RoutesOverview.css
@@ -60,10 +60,6 @@
   font-size: 14px;
 }
 
-.RoutesOverview_ascendDescend:before {
-  content: ' \00B7\00A0';
-}
-
 .RoutesOverview_acknowledgement {
   font-size: 14px;
   margin: 24px;

--- a/src/components/RoutesOverview.jsx
+++ b/src/components/RoutesOverview.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import classnames from 'classnames';
+import formatDistance from '../lib/formatDistance';
 import { TRANSIT_DATA_ACKNOWLEDGEMENT } from '../lib/region';
 import { formatInterval } from '../lib/time';
 import Icon from './Icon';
@@ -99,6 +100,14 @@ export default function RoutesOverview({
                   ),
                 }}
               />
+              {route.ascend != null &&
+                route.descend != null &&
+                Math.min(route.ascend, route.descend) > 10 && (
+                  <span className="RoutesOverview_ascendDescend">
+                    Up {formatDistance(route.ascend, intl)}, Down{' '}
+                    {formatDistance(route.descend, intl)}
+                  </span>
+                )}
             </p>
           </SelectionListItem>
         ))}

--- a/src/components/RoutesOverview.jsx
+++ b/src/components/RoutesOverview.jsx
@@ -9,6 +9,8 @@ import RouteLeg from './RouteLeg';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';
 
+import { ReactComponent as ArrowDown } from 'iconoir/icons/arrow-down.svg';
+import { ReactComponent as ArrowUp } from 'iconoir/icons/arrow-up.svg';
 import { ReactComponent as NavArrowRight } from 'iconoir/icons/nav-arrow-right.svg';
 
 import './RoutesOverview.css';
@@ -103,8 +105,44 @@ export default function RoutesOverview({
               {route.ascend != null &&
                 route.descend != null &&
                 Math.min(route.ascend, route.descend) > 10 && (
-                  <span className="RoutesOverview_ascendDescend">
-                    Up {formatDistance(route.ascend, intl)}, Down{' '}
+                  <span className="ml-3">
+                    <Icon
+                      alt={
+                        intl.formatMessage({
+                          defaultMessage: 'Elevation gain',
+                          description:
+                            'Accessible alt text for an up-arrow icon that ' +
+                            'appears next to a measurement of the elevation gain on a ' +
+                            'route, such as (in English) 200 ft or 50 m.',
+                        }) + ' '
+                      }
+                      className="relative top-0.5"
+                    >
+                      <ArrowUp
+                        width="16"
+                        height="16"
+                        className="stroke-2 text-gray-600"
+                      />
+                    </Icon>
+                    {formatDistance(route.ascend, intl)}
+                    <Icon
+                      alt={
+                        intl.formatMessage({
+                          defaultMessage: 'Elevation loss',
+                          description:
+                            'Accessible alt text for a down-arrow icon that ' +
+                            'appears next to a measurement of the elevation loss on a ' +
+                            'route, such as (in English) 200 ft or 50 m.',
+                        }) + ' '
+                      }
+                      className="relative top-0.5 ml-1"
+                    >
+                      <ArrowDown
+                        width="16"
+                        height="16"
+                        className="stroke-2 text-gray-600"
+                      />
+                    </Icon>
                     {formatDistance(route.descend, intl)}
                   </span>
                 )}


### PR DESCRIPTION
This shows the ascent/descent for returned routes, if provided by the server (which requires https://github.com/bikehopper/graphhopper/pull/95 to be merged and deployed, or something like it), and if the ascent/descent exceed a threshold, i.e., if the route is not nearly flat.

![image](https://github.com/bikehopper/bikehopper-ui/assets/1730853/a58aa861-9618-4edd-9709-56df5d307b29)
