### PR TITLE
Check locations are same after hydrating

### DIFF
--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -274,6 +274,19 @@ export function locationsSubmitted() {
       promiseResult.status === 'fulfilled' ? promiseResult.value : null,
     );
 
+    // If locations have since been changed, do nothing.
+    // (This can happen if a geocode/geolocate took a long time and in the
+    // meantime the user changed the location to a different one.)
+    const routeParamsAfterHydration = getState().routeParams;
+    if (
+      routeParamsAfterHydration.start !== start ||
+      routeParamsAfterHydration.startInputText !== startInputText ||
+      routeParamsAfterHydration.end !== end ||
+      routeParamsAfterHydration.endInputText !== endInputText
+    ) {
+      return;
+    }
+
     dispatch({
       type: 'locations_set',
       start: resultingStartLocation,


### PR DESCRIPTION
Geocoding an address/place name is asynchronous. So is geolocating the user (it sometimes takes 20+ sec on my laptop). So after we hydrate locations by geocoding/geolocating, we should check to make sure the user hasn't changed them in the meantime, and avoid overwriting any changes.

Fixes #180