### PR TITLE
Fix map controls getting stuck when top bar hides

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -53,15 +53,22 @@ function App(props) {
     );
   }
 
+  const shouldDisplayTopBar = !viewingDetails;
+  const [haveTopBarIncludingFade, setHaveTopBarIncludingFade] = React.useState(
+    !shouldDisplayTopBar,
+  );
+
   const topBar = (
     <Transition
-      show={!viewingDetails}
+      show={shouldDisplayTopBar}
       enter="transition-opacity ease-out duration-300"
       enterFrom="opacity-0"
       enterTo="opacity-100"
       leave="transition-opacity ease-in duration-200"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
+      beforeEnter={() => setHaveTopBarIncludingFade(true)}
+      afterLeave={() => setHaveTopBarIncludingFade(false)}
     >
       <TopBar
         showSearchBar={isEditingLocations || hasLocations || hasRoutes}
@@ -81,6 +88,10 @@ function App(props) {
         <AlertBar />
         <MapPlusOverlay
           topContent={topBar}
+          topBarEmpty={
+            /* prop change forces controls to move */
+            !haveTopBarIncludingFade
+          }
           hideMap={isEditingLocations}
           bottomContent={bottomContent}
         />


### PR DESCRIPTION
I forgot to account for the map top controls in #297, causing this:

![image](https://github.com/bikehopper/bikehopper-ui/assets/1730853/46bdf2c4-7673-486a-8b36-9e37b9b332e0)

This is kind of a hacky fix. A prop is passed in which isn't actually used, but it forces a re-render, so the `useLayoutEffect` in `MapPlusOverlay` recomputes the position of the map top controls.