### PR TITLE
Store OSM IDs with type attached

### DIFF
--- a/src/components/SearchAutocompleteDropdown.jsx
+++ b/src/components/SearchAutocompleteDropdown.jsx
@@ -110,7 +110,10 @@ export default function SearchAutocompleteDropdown(props) {
 
       // Limit result size, don't show the location already selected as start
       // point as a candidate for end point (or vice versa), and hydrate.
-      const otherId = state.routeParams[other]?.point?.properties?.osm_id;
+      const otherId =
+        state.routeParams[other]?.point?.properties?.osm_id &&
+        state.routeParams[other].point.properties.osm_type +
+          state.routeParams[other].point.properties.osm_id;
       const shownFeatures = [
         ...autocompleteFeatureIds.map((id) => state.geocoding.osmCache[id]),
         ...recentlyUsedFeatureIds.map((id) => ({
@@ -118,7 +121,11 @@ export default function SearchAutocompleteDropdown(props) {
           fromRecentlyUsed: true,
         })),
       ]
-        .filter((feat) => feat.properties.osm_id !== otherId)
+        .filter(
+          (feat) =>
+            feat?.properties?.osm_type &&
+            feat.properties.osm_type + feat.properties.osm_id !== otherId,
+        )
         .slice(0, 8);
 
       return {

--- a/src/features/storage.js
+++ b/src/features/storage.js
@@ -51,12 +51,15 @@ export function initFromStorage() {
       typeof entry.ts === 'number' &&
       typeof entry.obj === 'object' &&
       typeof entry.obj.properties === 'object' &&
-      typeof entry.obj.properties.osm_id === 'number'
+      typeof entry.obj.properties.osm_id === 'number' &&
+      ['N', 'R', 'W'].includes(entry.obj.properties.osm_type)
     ) {
-      osmCache[entry.obj.properties.osm_id] = entry.obj;
+      const idWithType =
+        entry.obj.properties.osm_type + entry.obj.properties.osm_id;
+      osmCache[idWithType] = entry.obj;
       recentlyUsedCooked.push({
         lastUsed: entry.ts,
-        id: entry.obj.properties.osm_id,
+        id: idWithType,
       });
     } else if (process.env.NODE_ENV !== 'production') {
       console.warn('Ignoring invalid recently used entry:', entry);


### PR DESCRIPTION
Geocoding results can be a node, way, or relation. Just using the OSM ID alone is ambiguous, as the node with ID 100 (say) has nothing to do with the way with ID 100, etc.

This commit solves the issue by using strings that begin with "N", "W", or "R", followed by a stringified ID, everywhere OSM IDs are used as a key. The format used to save recently-used locations in localStorage does not change. Fixes #302