### PR TITLE
Autocomplete: "no results found," spinner, etc

### DIFF
--- a/src/components/SearchAutocompleteDropdown.jsx
+++ b/src/components/SearchAutocompleteDropdown.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import classnames from 'classnames';
+import MoonLoader from 'react-spinners/MoonLoader';
 import { removeRecentlyUsedLocation } from '../features/geocoding';
 import {
   LocationSourceType,
@@ -195,10 +196,12 @@ export default function SearchAutocompleteDropdown(props) {
           />
         ))}
       </SelectionList>
-      <div className="px-8 py-4">
-        {loading && <span>loading...</span>}
-        {noResults && <span>nothing found</span>}
-      </div>
+      {(loading || noResults) && (
+        <div className="absolute inset-x-0 pt-4 pl-12 pointer-events-none">
+          <MoonLoader size={30} loading={loading} />
+          {noResults && <span>nothing found</span>}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/SearchAutocompleteDropdown.jsx
+++ b/src/components/SearchAutocompleteDropdown.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import classnames from 'classnames';
 import MoonLoader from 'react-spinners/MoonLoader';
@@ -31,9 +31,11 @@ export default function SearchAutocompleteDropdown(props) {
       'option that can be selected (or typed in) to get directions from or ' +
       'to the current location of the user, as determined by GPS',
   });
+  const strong = React.useCallback((txt) => <strong>{txt}</strong>, []);
 
   const {
     startOrEnd,
+    inputText,
     autocompletedText,
     features,
     showCurrentLocationOption,
@@ -137,6 +139,7 @@ export default function SearchAutocompleteDropdown(props) {
 
     return {
       startOrEnd,
+      inputText,
       autocompletedText,
       features: shownFeatures,
       showCurrentLocationOption,
@@ -200,7 +203,15 @@ export default function SearchAutocompleteDropdown(props) {
       {(loading || noResults) && (
         <div className="relative inset-x-0 pt-4 pl-12 pointer-events-none">
           <MoonLoader size={30} loading={loading} />
-          {noResults && <span>nothing found</span>}
+          {noResults && (
+            <span className="text-sm">
+              <FormattedMessage
+                defaultMessage="Nothing found for ''{inputText}''"
+                description="Message when no search results are found"
+                values={{ inputText, strong }}
+              />
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/src/components/SearchAutocompleteDropdown.jsx
+++ b/src/components/SearchAutocompleteDropdown.jsx
@@ -31,109 +31,117 @@ export default function SearchAutocompleteDropdown(props) {
       'to the current location of the user, as determined by GPS',
   });
 
-  const { startOrEnd, autocompletedText, features, showCurrentLocationOption } =
-    useSelector((state) => {
-      const startOrEnd = state.routeParams.editingLocation;
+  const {
+    startOrEnd,
+    autocompletedText,
+    features,
+    showCurrentLocationOption,
+    loading,
+    noResults, // we explicitly searched and found no results
+  } = useSelector((state) => {
+    const startOrEnd = state.routeParams.editingLocation;
+    const inputText = state.routeParams[startOrEnd + 'InputText'];
+    let autocompletedText = inputText; // May get changed below
+    let cache =
+      inputText && state.geocoding.typeaheadCache['@' + inputText.trim()];
+    let fallbackToGeocodedLocationSourceText = false;
+    let loading = false;
+    let noResults = false;
+    if (!cache || cache.status !== 'succeeded') {
+      if (cache?.status === 'fetching') loading = true;
+      // TODO: should we distinguish b/t server error & no match?
+      if (cache?.status === 'failed') noResults = true;
 
-      // TODO: Remove this after verifying it doesn't happen
-      if (!startOrEnd) throw new Error('expected to be editing start or end');
-
-      const inputText = state.routeParams[startOrEnd + 'InputText'];
-      let autocompletedText = inputText; // MAy get changed below
-      let cache =
-        inputText && state.geocoding.typeaheadCache['@' + inputText.trim()];
-      let fallbackToGeocodedLocationSourceText = false;
-      if (!cache || cache.status !== 'succeeded') {
-        // If the location we're editing has a geocoded location already selected, display the
-        // other options from the input text that was used to pick that.
-        const relevantLocation = state.routeParams[startOrEnd];
-        if (
-          relevantLocation &&
-          relevantLocation.source === LocationSourceType.Geocoded &&
-          relevantLocation.fromInputText &&
-          (inputText === '' ||
-            inputText === describePlace(relevantLocation.point))
+      // If the location we're editing has a geocoded location already selected, display the
+      // other options from the input text that was used to pick that.
+      const relevantLocation = state.routeParams[startOrEnd];
+      if (
+        relevantLocation &&
+        relevantLocation.source === LocationSourceType.Geocoded &&
+        relevantLocation.fromInputText &&
+        (inputText === '' ||
+          inputText === describePlace(relevantLocation.point))
+      ) {
+        autocompletedText = relevantLocation.fromInputText;
+        cache = state.geocoding.typeaheadCache['@' + autocompletedText.trim()];
+        fallbackToGeocodedLocationSourceText = true;
+      } else if (loading) {
+        // Still nothing? Try prefixes of the input text. Example: current input text is
+        // "123 Main St" which hasn't been looked up yet but we have results for "123 Mai",
+        // which came back while you were typing.
+        let strippedChars = 0;
+        while (
+          autocompletedText &&
+          (!cache || cache.status !== 'succeeded') &&
+          strippedChars++ < 8
         ) {
-          autocompletedText = relevantLocation.fromInputText;
+          autocompletedText = autocompletedText.substr(
+            0,
+            autocompletedText.length - 1,
+          );
           cache =
             state.geocoding.typeaheadCache['@' + autocompletedText.trim()];
-          fallbackToGeocodedLocationSourceText = true;
-        } else {
-          // Still nothing? Try prefixes of the input text. Example: current input text is
-          // "123 Main St" which hasn't been looked up yet but we have results for "123 Mai",
-          // which came back while you were typing.
-          let strippedChars = 0;
-          while (
-            autocompletedText &&
-            (!cache || cache.status !== 'succeeded') &&
-            strippedChars++ < 8
-          ) {
-            autocompletedText = autocompletedText.substr(
-              0,
-              autocompletedText.length - 1,
-            );
-            cache =
-              state.geocoding.typeaheadCache['@' + autocompletedText.trim()];
-          }
         }
       }
+    }
 
-      const other = startOrEnd === 'start' ? 'end' : 'start';
-      const canUseCurrentLocation =
-        'geolocation' in navigator &&
-        (!state.routeParams[other] ||
-          state.routeParams[other].source !==
-            LocationSourceType.UserGeolocation);
+    const other = startOrEnd === 'start' ? 'end' : 'start';
+    const canUseCurrentLocation =
+      'geolocation' in navigator &&
+      (!state.routeParams[other] ||
+        state.routeParams[other].source !== LocationSourceType.UserGeolocation);
 
-      // Only show the current location option if typed text is 1) blank, or 2)
-      // a prefix of "Current Location", case-insensitive
-      const showCurrentLocationOption =
-        canUseCurrentLocation &&
-        (fallbackToGeocodedLocationSourceText ||
-          currentLocationString
-            .toLocaleLowerCase(intl.locale)
-            .startsWith(inputText.toLocaleLowerCase(intl.locale)));
+    // Only show the current location option if typed text is 1) blank, or 2)
+    // a prefix of "Current Location", case-insensitive
+    const showCurrentLocationOption =
+      canUseCurrentLocation &&
+      (fallbackToGeocodedLocationSourceText ||
+        currentLocationString
+          .toLocaleLowerCase(intl.locale)
+          .startsWith(inputText.toLocaleLowerCase(intl.locale)));
 
-      let recentlyUsedFeatureIds = [];
-      let autocompleteFeatureIds = [];
+    let recentlyUsedFeatureIds = [];
+    let autocompleteFeatureIds = [];
 
-      if (inputText === '') {
-        // Suggest recently used locations
-        // NOTE: This is currently only done if input text is empty, but we
-        // could switch to always showing recently used locations that match
-        // the text typed, alongside Photon results.
-        recentlyUsedFeatureIds = state.geocoding.recentlyUsed.map((r) => r.id);
-      } else if (cache && cache.status === 'succeeded') {
-        autocompleteFeatureIds = cache.osmIds;
-      }
+    if (inputText === '') {
+      // Suggest recently used locations
+      // NOTE: This is currently only done if input text is empty, but we
+      // could switch to always showing recently used locations that match
+      // the text typed, alongside Photon results.
+      recentlyUsedFeatureIds = state.geocoding.recentlyUsed.map((r) => r.id);
+    } else if (cache && cache.status === 'succeeded') {
+      autocompleteFeatureIds = cache.osmIds;
+    }
 
-      // Limit result size, don't show the location already selected as start
-      // point as a candidate for end point (or vice versa), and hydrate.
-      const otherId =
-        state.routeParams[other]?.point?.properties?.osm_id &&
-        state.routeParams[other].point.properties.osm_type +
-          state.routeParams[other].point.properties.osm_id;
-      const shownFeatures = [
-        ...autocompleteFeatureIds.map((id) => state.geocoding.osmCache[id]),
-        ...recentlyUsedFeatureIds.map((id) => ({
-          ...state.geocoding.osmCache[id],
-          fromRecentlyUsed: true,
-        })),
-      ]
-        .filter(
-          (feat) =>
-            feat?.properties?.osm_type &&
-            feat.properties.osm_type + feat.properties.osm_id !== otherId,
-        )
-        .slice(0, 8);
+    // Limit result size, don't show the location already selected as start
+    // point as a candidate for end point (or vice versa), and hydrate.
+    const otherId =
+      state.routeParams[other]?.point?.properties?.osm_id &&
+      state.routeParams[other].point.properties.osm_type +
+        state.routeParams[other].point.properties.osm_id;
+    const shownFeatures = [
+      ...autocompleteFeatureIds.map((id) => state.geocoding.osmCache[id]),
+      ...recentlyUsedFeatureIds.map((id) => ({
+        ...state.geocoding.osmCache[id],
+        fromRecentlyUsed: true,
+      })),
+    ]
+      .filter(
+        (feat) =>
+          feat?.properties?.osm_type &&
+          feat.properties.osm_type + feat.properties.osm_id !== otherId,
+      )
+      .slice(0, 8);
 
-      return {
-        startOrEnd,
-        autocompletedText,
-        features: shownFeatures,
-        showCurrentLocationOption,
-      };
-    }, shallowEqual);
+    return {
+      startOrEnd,
+      autocompletedText,
+      features: shownFeatures,
+      showCurrentLocationOption,
+      loading,
+      noResults,
+    };
+  }, shallowEqual);
 
   const handleClick = (index) => {
     dispatch(
@@ -187,6 +195,10 @@ export default function SearchAutocompleteDropdown(props) {
           />
         ))}
       </SelectionList>
+      <div className="px-8 py-4">
+        {loading && <span>loading...</span>}
+        {noResults && <span>nothing found</span>}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Several improvements to the search autocomplete:

1. Shows loading spinner while fetching suggestions
2. Shows an explicit "Nothing found" message if nothing is found, rather than staying blank
3. Keeps stale suggestions while fetching new ones (more below)

![Screenshot from 2024-02-01 15-52-36](https://github.com/bikehopper/bikehopper-ui/assets/1730853/cf7f2004-c76d-41d7-9420-1c449d90a5b0)
![Screenshot from 2024-02-01 15-52-42](https://github.com/bikehopper/bikehopper-ui/assets/1730853/68388f70-16ee-4a20-9165-b2ab00ebd91b)

## Keeping stale suggestions while fetching new ones

Why do this? Try this:

1. With the default Bay Area-wide viewport, type: 701 ala
2. Wait for results
3. Clear out of inputs
4. Zoom to just SF
5. Again type 701 ala

Behavior before this commit:

1. While waiting 700ms to debounce, you see stale results
2. Geocode request kicks off ("geocode_attempted"). Results disappear
3. Geocode request succeeds ("geocode_succeeded"). New results appear

On a fast connection this looks like results flickering away for no good reason.

With this commit, you see the stale results at both steps 1 & 2, until new results immediately replace them at step 3.