### PR TITLE
tailwindify Icon and move to primitives

### DIFF
--- a/src/components/AlertBar.jsx
+++ b/src/components/AlertBar.jsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import classnames from 'classnames';
 import { AlertSeverity, dismissAlert } from '../features/alerts';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 
 import { ReactComponent as Cancel } from 'iconoir/icons/cancel.svg';
 import { ReactComponent as WarningCircle } from 'iconoir/icons/warning-circle.svg';

--- a/src/components/DirectionsNullState.jsx
+++ b/src/components/DirectionsNullState.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { ReactComponent as MagnifyingGlass } from 'iconoir/icons/search.svg';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import { SupportedRegionText } from '../lib/region';
 
 import './DirectionsNullState.css';

--- a/src/components/Icon.css
+++ b/src/components/Icon.css
@@ -1,3 +1,0 @@
-.Icon_flipHorizontally > svg {
-  transform: scale(-1, 1);
-}

--- a/src/components/Itinerary.jsx
+++ b/src/components/Itinerary.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { formatDurationBetween } from '../lib/time';
 import { getAgencyDisplayName } from '../lib/region';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import ItineraryBikeLeg from './ItineraryBikeLeg';
 import ItineraryHeader from './ItineraryHeader';
 import ItineraryTransitLeg from './ItineraryTransitLeg';

--- a/src/components/ItineraryHeader.jsx
+++ b/src/components/ItineraryHeader.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import classnames from 'classnames';
 import { getTextColor } from '../lib/colors';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import ItineraryRow from './ItineraryRow';
 import { ReactComponent as WarningTriangle } from 'iconoir/icons/warning-triangle.svg';
 

--- a/src/components/ItineraryStep.jsx
+++ b/src/components/ItineraryStep.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import ItineraryRow from './ItineraryRow';
 
 import './ItineraryStep.css';

--- a/src/components/PlaceIcon.jsx
+++ b/src/components/PlaceIcon.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 
 import { ReactComponent as Building } from 'iconoir/icons/building.svg';
 import { ReactComponent as Chocolate } from 'iconoir/icons/chocolate.svg';

--- a/src/components/RouteLeg.jsx
+++ b/src/components/RouteLeg.jsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import { DEFAULT_PT_COLOR, getTextColor } from '../lib/colors';
 import ModeIcon from './ModeIcon';
 import { MODES } from '../lib/TransitModes';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import { ReactComponent as Bicycle } from 'iconoir/icons/bicycle.svg';
 import { ReactComponent as WarningTriangle } from 'iconoir/icons/warning-triangle.svg';
 import { formatInterval } from '../lib/time';

--- a/src/components/RouteOptionsDialog.jsx
+++ b/src/components/RouteOptionsDialog.jsx
@@ -3,7 +3,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import ModalDialog from './primitives/ModalDialog';
 import DialogSubmitButton from './primitives/DialogSubmitButton';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import usePrevious from '../hooks/usePrevious';
 import { CATEGORIES } from '../lib/TransitModes';
 

--- a/src/components/RoutesOverview.jsx
+++ b/src/components/RoutesOverview.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import formatDistance from '../lib/formatDistance';
 import { TRANSIT_DATA_ACKNOWLEDGEMENT } from '../lib/region';
 import { formatInterval } from '../lib/time';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import RouteLeg from './RouteLeg';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';

--- a/src/components/SearchAutocompleteDropdown.jsx
+++ b/src/components/SearchAutocompleteDropdown.jsx
@@ -10,7 +10,7 @@ import {
   selectGeocodedLocation,
 } from '../features/routeParams';
 import describePlace from '../lib/describePlace';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import PlaceIcon from './PlaceIcon';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import PlaceIcon from './PlaceIcon';
 import TimeBar from './TimeBar';
 import {

--- a/src/components/SelectionListItem.jsx
+++ b/src/components/SelectionListItem.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useIntl } from 'react-intl';
 import classnames from 'classnames';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 
 import { ReactComponent as CancelIcon } from 'iconoir/icons/cancel.svg';
 

--- a/src/components/TimeBar.jsx
+++ b/src/components/TimeBar.jsx
@@ -5,7 +5,7 @@ import ModalDialog from './primitives/ModalDialog';
 import DialogSubmitButton from './primitives/DialogSubmitButton';
 import * as RadioGroup from '@radix-ui/react-radio-group';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 
 import { departureChanged } from '../features/routeParams';
 

--- a/src/components/primitives/Icon.jsx
+++ b/src/components/primitives/Icon.jsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
 
-import './Icon.css';
-
 // Usage:
 // import {ReactComponent as Blah} from 'iconoir/icons/blah.svg';
 // <Icon><Blah /></Icon>
@@ -22,8 +20,7 @@ export default function Icon(props) {
       aria-hidden={!props.label}
       aria-label={props.label}
       className={classnames({
-        Icon: true,
-        Icon_flipHorizontally: props.flipHorizontally,
+        '-scale-x-100': props.flipHorizontally,
         [props.className]: !!props.className,
       })}
     >

--- a/src/components/primitives/ModalDialog.jsx
+++ b/src/components/primitives/ModalDialog.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { Transition } from '@headlessui/react';
 import * as Dialog from '@radix-ui/react-dialog';
-import Icon from '../Icon';
+import Icon from './Icon';
 
 import { ReactComponent as CancelIcon } from 'iconoir/icons/cancel.svg';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
         bikehoppergreenlight: '#def0cc',
         bikehopperyellow: '#ffd18e',
       },
+      scale: {
+        '-100': '-1', // allow flipping
+      },
     },
   },
   plugins: [require('@tailwindcss/typography')],


### PR DESCRIPTION
Converts `<Icon>` component to TailwindCSS and moves it to the primitives directory