### PR TITLE
Fix mispositioned control after top bar fades

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -54,9 +54,8 @@ function App(props) {
   }
 
   const shouldDisplayTopBar = !viewingDetails;
-  const [haveTopBarIncludingFade, setHaveTopBarIncludingFade] = React.useState(
-    !shouldDisplayTopBar,
-  );
+  const [haveTopBarIncludingFade, setHaveTopBarIncludingFade] =
+    React.useState(shouldDisplayTopBar);
 
   const topBar = (
     <Transition


### PR DESCRIPTION
Fixes #318. The sense of the default state of this variable was reversed, causing this bug to happen the very first time the top bar faded away in a session.