### PR TITLE
Hiker icon for highway=path

### DIFF
--- a/src/components/PlaceIcon.jsx
+++ b/src/components/PlaceIcon.jsx
@@ -63,7 +63,8 @@ function _getSvgComponentForFeature(feature) {
     Klass = Summit;
   } else if (
     (key === 'natural' && (value === 'rock' || value === 'saddle')) ||
-    (key === 'highway' && value === 'footway' && type === 'street')
+    (key === 'highway' && value === 'footway' && type === 'street') ||
+    (key === 'highway' && value === 'path')
   ) {
     // mountain, trail
     Klass = Trekking;


### PR DESCRIPTION
Relevant case: Old Guadalupe Trail [in San Bruno Mountain Park]

Before: Generic pushpin icon
Now: 
![image](https://github.com/bikehopper/bikehopper-ui/assets/1730853/9660436a-6f99-41f1-bb2f-d421464a5bdd)
