### PR TITLE
Search bar: make clearing text easier

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -105,14 +105,19 @@ export default function SearchBar(props) {
 
   const handleFocus = (which, event) => {
     dispatch(locationInputFocused(which));
+
+    const relevantLocation = which === 'start' ? startLocation : endLocation;
+    const textModified =
+      which === 'start' ? startTextModified : endTextModified;
+    // If the input contains the magic string "Current Location", or if it contains
+    // unmodified text from the geocoder (often a very long address), select all to
+    // make it easier to delete.
     if (
-      (which === 'start' &&
-        startLocation?.source === LocationSourceType.UserGeolocation) ||
-      (which === 'end' &&
-        endLocation?.source === LocationSourceType.UserGeolocation)
+      relevantLocation &&
+      (relevantLocation.source === LocationSourceType.UserGeolocation ||
+        (relevantLocation.source === LocationSourceType.Geocoded &&
+          !textModified))
     ) {
-      // Select the "Current Location" text so that any key input will replace it in its
-      // entirety, since it doesn't make sense to edit this magic string otherwise.
       event.target.select();
     }
   };


### PR DESCRIPTION
Fixes #244:

> When you change your mind about where you were going and want to enter a new destination, it is annoying to have to clear the LONG text strings like
>
> >    Réveille Coffee Co., 200 Columbus Avenue, San Francisco, 94133
>
> that get put in there by the geocoder.

Focusing the start or end input will now select all contents, if the text is unmodified text from the geocoder. We were already doing this for the text "Current Location." There is no select all if you have hand-edited the text.