### PR TITLE
Fix more collapsible leg issues

### DIFF
--- a/src/components/ItineraryBikeLeg.jsx
+++ b/src/components/ItineraryBikeLeg.jsx
@@ -12,17 +12,14 @@ import ItineraryHeader from './ItineraryHeader';
 import ItinerarySpacer from './ItinerarySpacer';
 
 import { ReactComponent as BikeIcon } from 'iconoir/icons/bicycle.svg';
-import ItineraryElevationProfile from './ItineraryElevationProfile';
 
 export default function ItineraryBikeLeg({
   leg,
   legDestination,
-  isOnlyLeg,
   expanded,
   onStepClick,
   onToggleLegExpand,
   scrollToStep,
-  displayLegElevation,
 }) {
   const intl = useIntl();
   const instructionsWithBikeInfra = React.useMemo(() => {
@@ -78,7 +75,6 @@ export default function ItineraryBikeLeg({
         icon={bikeIcon}
         iconColor={BIKEHOPPER_THEME_COLOR}
         alerts={alerts}
-        displayArrow={!isOnlyLeg}
         expanded={expanded}
         alertsExpanded={true}
         onToggleLegExpand={onToggleLegExpand}
@@ -110,11 +106,6 @@ export default function ItineraryBikeLeg({
       {expanded ? (
         <div>
           <ItinerarySpacer />
-
-          {isOnlyLeg || !displayLegElevation ? null : (
-            <ItineraryElevationProfile route={{ legs: [leg] }} />
-          )}
-
           {instructionsWithBikeInfra.map((step, stepIdx) =>
             isArriveStep(step)
               ? null

--- a/src/components/ItineraryBikeLeg.jsx
+++ b/src/components/ItineraryBikeLeg.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { BIKEHOPPER_THEME_COLOR } from '../lib/colors';
 import formatDistance from '../lib/formatDistance';
@@ -22,7 +22,7 @@ export default function ItineraryBikeLeg({
   scrollToStep,
 }) {
   const intl = useIntl();
-  const instructionsWithBikeInfra = React.useMemo(() => {
+  const instructionsWithBikeInfra = useMemo(() => {
     return leg.instructions.map((step) => {
       return {
         ...step,
@@ -36,16 +36,7 @@ export default function ItineraryBikeLeg({
       };
     });
   }, [leg]);
-
-  const [majorStreets, setMajorStreets] = useState(null);
-
-  useEffect(() => {
-    async function getMajorStreets() {
-      const majorStreets = await formatMajorStreets(leg);
-      setMajorStreets(majorStreets);
-    }
-    getMajorStreets();
-  }, [leg]);
+  const majorStreets = useMemo(() => formatMajorStreets(leg), [leg]);
 
   const scrollToRef = useScrollToRef();
   const spacer = ' \u00B7 ';

--- a/src/components/ItineraryBikeLeg.jsx
+++ b/src/components/ItineraryBikeLeg.jsx
@@ -87,7 +87,9 @@ export default function ItineraryBikeLeg({
               <FormattedMessage
                 defaultMessage="via {streets}"
                 description="list of major streets taken on bike leg"
-                values={{ streets: majorStreets.join(', ') }}
+                values={{
+                  streets: intl.formatList(majorStreets, { type: 'unit' }),
+                }}
               />
             </>
           ) : null}

--- a/src/components/ItineraryHeader.jsx
+++ b/src/components/ItineraryHeader.jsx
@@ -23,10 +23,9 @@ export default function ItineraryHeader({
   icon,
   iconColor,
   iconLabel = '',
-  displayArrow = true,
   expanded,
-  alertsExpanded,
   onToggleLegExpand,
+  alertsExpanded,
   onAlertClick,
 }) {
   const intl = useIntl();
@@ -54,7 +53,7 @@ export default function ItineraryHeader({
         </span>
       </BorderlessButton>
       <span className="ItineraryHeader_headerRow">
-        {displayArrow ? (
+        {onToggleLegExpand ? (
           <BorderlessButton onClick={onToggleLegExpand} flex={true}>
             <Icon
               className="ItineraryHeader_arrow"

--- a/src/components/ItineraryTransitLeg.jsx
+++ b/src/components/ItineraryTransitLeg.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { DEFAULT_PT_COLOR } from '../lib/colors';
-import { modeToName } from '../lib/TransitModes';
+import { getModeLabel } from '../lib/TransitModes';
 import { formatTime, formatDurationBetween } from '../lib/time';
 import classnames from 'classnames';
 import { getAgencyDisplayName } from '../lib/region';
@@ -62,7 +62,7 @@ export default function ItineraryTransitLeg({
       <ItineraryHeader
         icon={<ModeIcon mode={leg.route_type} />}
         iconColor={leg.route_color || DEFAULT_PT_COLOR}
-        iconLabel={modeToName(leg.route_type)}
+        iconLabel={getModeLabel(leg.route_type, intl)}
         expanded={expanded}
         alertsExpanded={alertsExpanded}
         onToggleLegExpand={onToggleLegExpand}

--- a/src/components/ItineraryTransitLeg.jsx
+++ b/src/components/ItineraryTransitLeg.jsx
@@ -31,7 +31,7 @@ export default function ItineraryTransitLeg({
 
   const toggleAlertsExpanded = useCallback(
     () => setAlertsExpanded(!alertsExpanded),
-    [alertsExpanded, setAlertsExpanded],
+    [alertsExpanded],
   );
 
   const { stops } = leg;
@@ -41,6 +41,7 @@ export default function ItineraryTransitLeg({
 
   const stopsTraveled = stops.length - 1;
   const stopsBetweenStartAndEnd = stopsTraveled - 1;
+  const expandable = stopsBetweenStartAndEnd > 0;
 
   const spacerWithMiddot = ' \u00B7 ';
 
@@ -65,10 +66,9 @@ export default function ItineraryTransitLeg({
         iconLabel={getModeLabel(leg.route_type, intl)}
         expanded={expanded}
         alertsExpanded={alertsExpanded}
-        onToggleLegExpand={onToggleLegExpand}
+        onToggleLegExpand={expandable ? onToggleLegExpand : null}
         onAlertClick={toggleAlertsExpanded}
         alerts={alertsForHeader}
-        displayArrow={stops.length > 2}
       >
         <span>
           <FormattedMessage
@@ -157,26 +157,21 @@ export default function ItineraryTransitLeg({
             </ItineraryStep>
           ))}
         </div>
-      ) : stops.length > 2 ? (
+      ) : expandable ? (
         <div onClick={onToggleLegExpand}>
           <ItineraryDivider
-            transit={true}
-            detail={
-              stopsBetweenStartAndEnd > 0
-                ? intl.formatMessage(
-                    {
-                      defaultMessage:
-                        '{numStops} {numStops, plural,' +
-                        ' one {stop}' +
-                        ' other {stops}' +
-                        '} before',
-                      description:
-                        'the number of stops between two listed transit stops',
-                    },
-                    { numStops: stopsBetweenStartAndEnd },
-                  )
-                : null
-            }
+            detail={intl.formatMessage(
+              {
+                defaultMessage:
+                  '{numStops} {numStops, plural,' +
+                  ' one {stop}' +
+                  ' other {stops}' +
+                  '} before',
+                description:
+                  'the number of stops between two listed transit stops',
+              },
+              { numStops: stopsBetweenStartAndEnd },
+            )}
           />
         </div>
       ) : null}

--- a/src/components/RouteLeg.jsx
+++ b/src/components/RouteLeg.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { DEFAULT_PT_COLOR, getTextColor } from '../lib/colors';
 import ModeIcon from './ModeIcon';
-import { MODES } from '../lib/TransitModes';
+import { getModeLabel } from '../lib/TransitModes';
 import Icon from './primitives/Icon';
 import { ReactComponent as Bicycle } from 'iconoir/icons/bicycle.svg';
 import { ReactComponent as WarningTriangle } from 'iconoir/icons/warning-triangle.svg';
@@ -53,7 +53,7 @@ export default function RouteLeg(props) {
         {maybeAlertIcon}
         <Icon
           className="RouteLeg_transitModeIcon"
-          label={_getModeLabel(props.routeType, intl)}
+          label={getModeLabel(props.routeType, intl)}
         >
           <ModeIcon
             width="20"
@@ -85,93 +85,4 @@ export default function RouteLeg(props) {
       )}
     </div>
   );
-}
-
-function _getModeLabel(mode, intl) {
-  switch (mode) {
-    case MODES.TRAM_STREETCAR_LIGHT_RAIL:
-      return intl.formatMessage({
-        defaultMessage: 'Train',
-        description:
-          'labels a transit line as being operated by a tram, streetcar or light rail.' +
-          ' Appears next to the name or number of the line.' +
-          ' For American English, we match common usage by saying "train",' +
-          ' but "tram" might be appropriate for other dialects of English.',
-      });
-    case MODES.MONORAIL:
-      return intl.formatMessage({
-        defaultMessage: 'Monorail',
-        description:
-          'labels a transit line as being operated by a tram, streetcar or light rail.' +
-          ' Appears next to the name or number of the line.',
-      });
-    case MODES.SUBWAY_METRO:
-      return intl.formatMessage({
-        defaultMessage: 'Train',
-        description:
-          'labels a transit line as being operated by a train;' +
-          ' specifically a subway or metro train but the label need not be that specific.' +
-          ' Appears next to the name or number of the line.',
-      });
-    case MODES.RAIL_INTERCITY_LONG_DISTANCE:
-      return intl.formatMessage({
-        defaultMessage: 'Train',
-        description:
-          'labels a transit line as being operated by a train;' +
-          ' specifically intercity or long-distance rail,' +
-          ' but the label need not be that specific.' +
-          ' Appears next to the name or number of the line.',
-      });
-    case MODES.BUS:
-      return intl.formatMessage({
-        defaultMessage: 'Bus',
-        description:
-          'labels a transit line as being operated by a bus.' +
-          ' Appears next to the name or number of the bus line.',
-      });
-    case MODES.TROLLEYBUS:
-      return intl.formatMessage({
-        defaultMessage: 'Bus',
-        description:
-          'labels a transit line as being operated by a bus.' +
-          ' Specifically a trolleybus but the label need not be that specific.' +
-          ' Appears next to the name or number of the bus line.',
-      });
-    case MODES.FERRY:
-      return intl.formatMessage({
-        defaultMessage: 'Ferry',
-        description:
-          'labels a transit line as being operated by a ferry.' +
-          ' Appears next to the name or number of the line.',
-      });
-    case MODES.CABLE_TRAM:
-      return intl.formatMessage({
-        defaultMessage: 'Cable car',
-        description:
-          'labels a transit line as being operated by a cable tram/cable car.' +
-          ' Appears next to the name or number of the line.',
-      });
-    case MODES.AERIAL_TRAM_SUSPENDED_CABLE_CAR:
-      return intl.formatMessage({
-        defaultMessage: 'Cable car',
-        description:
-          'labels a transit line as being operated by an aerial tram or' +
-          ' suspended cable car.' +
-          ' Appears next to the name or number of the line.',
-      });
-    case MODES.FUNICULAR:
-      return intl.formatMessage({
-        defaultMessage: 'Funicular',
-        description:
-          'labels a transit line as being operated by a funicular.' +
-          ' Appears next to the name or number of the bus line.',
-      });
-    default:
-      return intl.formatMessage({
-        defaultMessage: 'Transit line',
-        description:
-          'label for transit line when the mode (bus, train, etc) is unknown.' +
-          ' Appears next to the name or number of the line.',
-      });
-  }
 }

--- a/src/components/RoutesOverview.jsx
+++ b/src/components/RoutesOverview.jsx
@@ -5,7 +5,6 @@ import formatDistance from '../lib/formatDistance';
 import { TRANSIT_DATA_ACKNOWLEDGEMENT } from '../lib/region';
 import { formatInterval } from '../lib/time';
 import Icon from './primitives/Icon';
-import { isSignificantLeg } from '../lib/leg';
 import RouteLeg from './RouteLeg';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';
@@ -47,7 +46,7 @@ export default function RoutesOverview({
           >
             <div className="RoutesOverview_row">
               <ul className="RoutesOverview_routeLegs">
-                {route.legs.filter(isSignificantLeg).map((leg, index) => (
+                {route.legs.filter(_isSignificantLeg).map((leg, index) => (
                   <React.Fragment key={route.nonce + ':' + index}>
                     {index > 0 && (
                       <li className="RoutesOverview_legSeparator">
@@ -182,5 +181,15 @@ function _outOfAreaMsg(intl, start, end) {
       description: 'warning shown above routes',
     },
     { which },
+  );
+}
+
+function _isSignificantLeg(leg) {
+  // For filtering out short, interpolated legs
+  const THRESHOLD_IN_METERS = 120;
+  return !(
+    leg.type === 'bike2' &&
+    leg.interpolated &&
+    leg.distance < THRESHOLD_IN_METERS
   );
 }

--- a/src/features/routes.js
+++ b/src/features/routes.js
@@ -123,7 +123,7 @@ export function routesReducer(state = DEFAULT_STATE, action) {
         }
       });
     case 'itinerary_back_clicked':
-      return { ...state, viewingDetails: false, viewingLeg: null };
+      return { ...state, viewingDetails: false };
     case 'itinerary_step_clicked':
       return { ...state, viewingStep: [action.leg, action.step] };
     case 'itinerary_step_back_clicked':

--- a/src/lib/TransitModes.js
+++ b/src/lib/TransitModes.js
@@ -37,27 +37,91 @@ export const CATEGORY_TO_MODES = {
   [CATEGORIES.FERRIES]: [MODES.FERRY],
 };
 
-export function modeToName(mode) {
+export function getModeLabel(mode, intl) {
   switch (mode) {
     case MODES.TRAM_STREETCAR_LIGHT_RAIL:
-      return 'tram/streetcar/light rail';
+      return intl.formatMessage({
+        defaultMessage: 'Train',
+        description:
+          'labels a transit line as being operated by a tram, streetcar or light rail.' +
+          ' Appears next to the name or number of the line.' +
+          ' For American English, we match common usage by saying "train",' +
+          ' but "tram" might be appropriate for other dialects of English.',
+      });
     case MODES.MONORAIL:
-      return 'monorail';
+      return intl.formatMessage({
+        defaultMessage: 'Monorail',
+        description:
+          'labels a transit line as being operated by a tram, streetcar or light rail.' +
+          ' Appears next to the name or number of the line.',
+      });
     case MODES.SUBWAY_METRO:
-      return 'subway/metro';
+      return intl.formatMessage({
+        defaultMessage: 'Train',
+        description:
+          'labels a transit line as being operated by a train;' +
+          ' specifically a subway or metro train but the label need not be that specific.' +
+          ' Appears next to the name or number of the line.',
+      });
     case MODES.RAIL_INTERCITY_LONG_DISTANCE:
-      return 'intercity/long-distance rail';
+      return intl.formatMessage({
+        defaultMessage: 'Train',
+        description:
+          'labels a transit line as being operated by a train;' +
+          ' specifically intercity or long-distance rail,' +
+          ' but the label need not be that specific.' +
+          ' Appears next to the name or number of the line.',
+      });
     case MODES.BUS:
+      return intl.formatMessage({
+        defaultMessage: 'Bus',
+        description:
+          'labels a transit line as being operated by a bus.' +
+          ' Appears next to the name or number of the bus line.',
+      });
     case MODES.TROLLEYBUS:
-      return 'bus';
+      return intl.formatMessage({
+        defaultMessage: 'Bus',
+        description:
+          'labels a transit line as being operated by a bus.' +
+          ' Specifically a trolleybus but the label need not be that specific.' +
+          ' Appears next to the name or number of the bus line.',
+      });
     case MODES.FERRY:
-      return 'ferry';
+      return intl.formatMessage({
+        defaultMessage: 'Ferry',
+        description:
+          'labels a transit line as being operated by a ferry.' +
+          ' Appears next to the name or number of the line.',
+      });
     case MODES.CABLE_TRAM:
+      return intl.formatMessage({
+        defaultMessage: 'Cable car',
+        description:
+          'labels a transit line as being operated by a cable tram/cable car.' +
+          ' Appears next to the name or number of the line.',
+      });
     case MODES.AERIAL_TRAM_SUSPENDED_CABLE_CAR:
-      return 'cable tram/cable car/aerial tram/suspended cable car';
+      return intl.formatMessage({
+        defaultMessage: 'Cable car',
+        description:
+          'labels a transit line as being operated by an aerial tram or' +
+          ' suspended cable car.' +
+          ' Appears next to the name or number of the line.',
+      });
     case MODES.FUNICULAR:
-      return 'funicular';
+      return intl.formatMessage({
+        defaultMessage: 'Funicular',
+        description:
+          'labels a transit line as being operated by a funicular.' +
+          ' Appears next to the name or number of the bus line.',
+      });
     default:
-      return 'unknown mode';
+      return intl.formatMessage({
+        defaultMessage: 'Transit line',
+        description:
+          'label for transit line when the mode (bus, train, etc) is unknown.' +
+          ' Appears next to the name or number of the line.',
+      });
   }
 }

--- a/src/lib/formatMajorStreets.js
+++ b/src/lib/formatMajorStreets.js
@@ -1,4 +1,4 @@
-export default async function formatMajorStreets(leg) {
+export default function formatMajorStreets(leg) {
   var distanceByStreetName = {};
   leg.instructions.forEach((instruction) => {
     if (!instruction.street_name) {
@@ -23,7 +23,7 @@ export default async function formatMajorStreets(leg) {
     return;
   }
 
-  var quartileDistance = await quartileStreets(streetsWithDistance, 0.85);
+  var quartileDistance = quartileStreets(streetsWithDistance, 0.85);
 
   var streetsOverQuartile = streetsWithDistance.filter((street) => {
     return street.totalDistance >= quartileDistance;
@@ -32,7 +32,7 @@ export default async function formatMajorStreets(leg) {
   return streetsOverQuartile.map((s) => s.name);
 }
 
-async function quartileStreets(streets, q) {
+function quartileStreets(streets, q) {
   streets = streets.concat([]);
   streets.sort((a, b) => {
     return a.totalDistance - b.totalDistance;

--- a/src/lib/leg.js
+++ b/src/lib/leg.js
@@ -1,9 +1,0 @@
-export function isSignificantLeg(leg) {
-  // For filtering out short, interpolated legs
-  const THRESHOLD_IN_METERS = 120;
-  return !(
-    leg.type === 'bike2' &&
-    leg.interpolated &&
-    leg.distance < THRESHOLD_IN_METERS
-  );
-}


### PR DESCRIPTION
PR to PR #324 implementing most of my feedback to that PR.

- Localizes the mode name labels by reusing code from RouteLeg
- Fully localizes the list of streets ("via Valencia Street, 14th Street")
- Removes useless use of async/await
- Removes unused viewingLeg member of routes reducer
- Fixes setState in render
- Allows expanding multiple legs at a time
- Misc cleanup

Not implemented because didn't seem blocking: Suggestion to use CSS to set the size (number of lines) of clamped alerts, using overflow: hidden and [text-overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow): ellipsis, instead of a character limit