### PR TITLE
Fix alerts scrolling horizontally

### DIFF
--- a/src/components/ItineraryHeader.jsx
+++ b/src/components/ItineraryHeader.jsx
@@ -102,7 +102,7 @@ export default function ItineraryHeader({
                 </>
               )}
               {alertBody && (
-                <span className="ItineraryHeader_alertBody">
+                <span className="break-words whitespace-pre-wrap hyphens-auto">
                   {alertsExpanded || alertBody.length <= ALERT_SUMMARY_LENGTH
                     ? alertBody
                     : alertSummary(alertBody)}


### PR DESCRIPTION
Before: (alert text has been modified to demonstrate the problem)
![Screenshot from 2024-04-30 09-41-42](https://github.com/bikehopper/bikehopper-ui/assets/1730853/756fdae4-7973-4cd9-aec8-64c18652400b)

After:
![Screenshot from 2024-04-30 09-41-49](https://github.com/bikehopper/bikehopper-ui/assets/1730853/353b6eda-e4f0-4051-b3cf-ccd3230c12bf)

Fixes #282