### PR TITLE
Fix URL router clearing locale

### DIFF
--- a/src/lib/urlMiddleware.js
+++ b/src/lib/urlMiddleware.js
@@ -32,7 +32,7 @@ export default function routesUrlMiddleware(store) {
       action.type === 'route_fetch_failed' &&
       history.location.pathname !== '/'
     ) {
-      history.replace('/');
+      history.replace('/' + history.location.search);
       return;
     } else if (routeStateBefore.routes === routeStateAfter.routes) {
       return;


### PR DESCRIPTION
We support overriding the locale like this (to get Spanish translations): `https://bikehopper.org/?locale=es-US`

Client-side routing should preserve that locale parameter, but it isn't preserving it in the case where a route fetch fails. This fixes.