### PR TITLE
After permission denied, don't default to geolocation

### DIFF
--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -395,9 +395,8 @@ export function locationSelectedOnMap(startOrEnd, coords) {
     });
 
     // If we have a location for the other point, fetch a route.
-    const state = getState();
     let { start, end, arriveBy, initialTime, connectingModes } =
-      state.routeParams;
+      getState().routeParams;
     if (startOrEnd === 'start' && end?.point?.geometry.coordinates) {
       await fetchRoute(
         coords,


### PR DESCRIPTION
Usually, BikeHopper defaults to geolocating your start location when you enter an end location (or select an end location on the map).

This commit makes it so that after geolocation fails due to a permission denied error, we will no longer attempt to default to it. We will just leave the start location field blank in those cases and let you manually select.

We'll restore the behavior of defaulting to geolocating your start location after the page is reloaded or after geolocation is manually selected and succeeds.

Fixes #342