### PR TITLE
Add fix to properly access lat/lon for fit file encoding

### DIFF
--- a/src/lib/getFitBlob.js
+++ b/src/lib/getFitBlob.js
@@ -33,12 +33,13 @@ function createRecordMessages(leg, startDate) {
     distance +=
       i > 0
         ? distanceBetween2Points(
-            leg.geometry.coordinates[i - 1].positionLat,
-            leg.geometry.coordinates[i - 1].positionLong,
-            m.positionLat,
-            m.positionLong,
+            leg.geometry.coordinates[i - 1][1],
+            leg.geometry.coordinates[i - 1][0],
+            m[1],
+            m[0],
           )
         : 0;
+
     return {
       positionLong: m[0],
       positionLat: m[1],


### PR DESCRIPTION
I missed this bug somehow after my refactor.  Even though I tested locally via on a computer via mapping apps, the cycling computer itself did not seem to like what was pushed to prod.  Fixed it, tested on actual device.