### PR TITLE
Lint: require async functions to use await

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
     'react/jsx-key': 'warn',
     'no-empty': ['warn', { allowEmptyCatch: true }],
     'no-constant-condition': 'warn',
+    'require-await': 'warn',
   },
   overrides: [
     {

--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -485,7 +485,7 @@ export function changeLocationTextInput(startOrEnd, value) {
       value,
     });
 
-    dispatch(
+    await dispatch(
       geocodeTypedLocation(value, startOrEnd, { fromTextAutocomplete: true }),
     );
   };
@@ -500,7 +500,7 @@ export function selectGeocodedLocation(startOrEnd, point, fromInputText) {
       fromInputText,
     });
 
-    dispatch(locationsSubmitted());
+    await dispatch(locationsSubmitted());
   };
 }
 
@@ -511,7 +511,7 @@ export function selectCurrentLocation(startOrEnd) {
       startOrEnd,
     });
 
-    dispatch(locationsSubmitted());
+    await dispatch(locationsSubmitted());
   };
 }
 
@@ -535,7 +535,7 @@ export function swapLocations() {
       type: 'locations_swapped',
     });
 
-    dispatch(locationsSubmitted());
+    await dispatch(locationsSubmitted());
   };
 }
 
@@ -550,7 +550,7 @@ export function departureChanged(departureType, initialTime) {
     });
 
     // If we have a location, fetch a route.
-    dispatch(locationsSubmitted());
+    await dispatch(locationsSubmitted());
   };
 }
 
@@ -562,7 +562,7 @@ export function changeConnectingModes(newConnectingModes) {
     });
 
     // If we have a location, fetch a route.
-    dispatch(locationsSubmitted());
+    await dispatch(locationsSubmitted());
   };
 }
 


### PR DESCRIPTION
Also: Fix some technically incorrect async action creators to not resolve before the underlying async action completes. I don't think this resulted in any visible bug as written.