### PR TITLE
Fix bug where geolocation clobbers start point

### DIFF
--- a/src/features/routeParams.js
+++ b/src/features/routeParams.js
@@ -409,7 +409,17 @@ export function locationSelectedOnMap(startOrEnd, coords) {
       // Potentially geolocate user for start point
       if (start?.source === LocationSourceType.UserGeolocation) {
         await dispatch(geolocate());
-        const { lng, lat } = getState().geolocation;
+
+        const stateAfterGeolocate = getState();
+        if (
+          !stateAfterGeolocate.start ||
+          stateAfterGeolocate.start.source !==
+            LocationSourceType.UserGeolocation
+        ) {
+          // While geolocating, a different start point was selected.
+          return;
+        }
+        const { lng, lat } = stateAfterGeolocate.geolocation;
         if (lng == null || lat == null) return;
 
         start = {


### PR DESCRIPTION
Fixes a bug where

1. You select a destination by right-click/long-press on map
2. Geolocating you takes a long time
3. In the meantime, you enter a manual start location

-> the eventual geolocated location would clobber the manual start location.

I thought I'd already fixed this, and I had, but not for the choose-on-map case.