### PR TITLE
Distinguish bike colors more

### DIFF
--- a/src/lib/colors.js
+++ b/src/lib/colors.js
@@ -1,8 +1,8 @@
 import Color from 'color';
 
-export const DEFAULT_BIKE_COLOR = '#5c5c3d';
+export const DEFAULT_BIKE_COLOR = '#6b6b47';
 export const BIKE_LANE_COLOR = '#33cc33';
-export const CYCLE_TRACK_COLOR = '#006600';
+export const CYCLE_TRACK_COLOR = '#0c8014';
 export const DEFAULT_PT_COLOR = '#4169e1';
 export const DEFAULT_INACTIVE_COLOR = 'darkgray';
 export const BIKEHOPPER_THEME_COLOR = '#5aaa0a';


### PR DESCRIPTION
We display bike routes as dark gray (asphalt color) if there's no bike infrastructure on that street, and dark green if there's an off-street path or protected bike lane. Currently, those two colors are hard to distinguish:

![Screenshot from 2024-05-29 18-53-26](https://github.com/bikehopper/bikehopper-ui/assets/1730853/6d683a19-49c9-4a70-aa14-f30b91a06732)

This PR will make them a little easier to distinguish:

![Screenshot from 2024-05-29 18-53-40](https://github.com/bikehopper/bikehopper-ui/assets/1730853/28f2c32b-7f41-4989-be79-81f08c8fd851)

Fixes #120.
