### PR TITLE
split out some big vendor modules into their own files

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,27 @@ import babelPluginFormatjs from 'babel-plugin-formatjs';
 export default defineConfig(() => {
   return {
     build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'maplibre-gl': ['maplibre-gl'],
+            gpx2fit: ['gpx2fit'],
+            '@nivo': ['@nivo/core', '@nivo/line'],
+            '@turf': [
+              '@turf/bezier-spline',
+              '@turf/boolean-point-in-polygon',
+              '@turf/buffer',
+              '@turf/convex',
+              '@turf/distance',
+              '@turf/helpers',
+              '@turf/length',
+              '@turf/line-slice-along',
+              '@turf/meta',
+              '@turf/transform-rotate',
+            ],
+          },
+        },
+      },
       outDir: 'build',
     },
     plugins: [


### PR DESCRIPTION
this breaks our giant index.js into a few smaller files so they will be loaded in parallel. it should offer improved time to first paint because the data comes in faster while also improving out cache hit rate for these files because now turf and maplibre can be cached in a CDN and on device and will be reusable across deploys UI deploys so long as we dont change package versions. since we update these far less often than we update our own code this will basically halve the amount of data that needs to be downloaded for most page loads. 

There is more that could be done on this front, such as bundling other stuff that changes infrequently into its own files, targeting 500kb per file, and pointing our react and maplibre to external CDN versions so we can get cache hit from other sites. but that introduces other complexity i dont think we need right now. 