### PR TITLE
Add docker based dev env

### DIFF
--- a/.env.development.template
+++ b/.env.development.template
@@ -5,3 +5,4 @@ VITE_MAPBOX_TOKEN="pk.CHANGEME"
 # If you want to select a local, rather than deployed, graphhopper instance:
 #VITE_USE_LOCAL_GRAPHHOPPER = http://localhost:8989
 #API_DOMAIN = https://api.app.localhost
+#OPEN_BROWSER = false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+services:
+  bikehopper-ui-setup:
+    container_name: bikehopper-ui-setup
+    working_dir: /home/node/app
+    env_file:
+      - path: .env.development.local
+        required: true
+    image: node
+    labels:
+      - 'app=bikehopper-ui-setup'
+    volumes:
+      - '.:/home/node/app'
+    command: ['npm', 'install']
+  bikehopper-ui-dev:
+    container_name: bikehopper-ui-dev
+    working_dir: /home/node/app
+    env_file:
+      - path: .env.development.local
+        required: true
+    image: node
+    labels:
+      - 'app=bikehopper-ui-dev'
+    volumes:
+      - '.:/home/node/app'
+    ports:
+      - 9229:9229
+      - 3000:3000
+    command: ['npm', 'start']
+    depends_on:
+      bikehopper-ui-setup:
+        condition: service_completed_successfully

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,8 +27,8 @@ services:
     volumes:
       - '.:/home/node/app'
     ports:
-      - 9229:9229
-      - 3000:3000
+      - 127.0.0.1:9229:9229
+      - 127.0.0.1:3000:3000
     command: ['npm', 'start', '--', '--host']
     depends_on:
       bikehopper-ui-setup:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     env_file:
       - path: .env.development.local
         required: true
-    image: node
+    image: node:20
     labels:
       - 'app=bikehopper-ui-setup'
     volumes:
@@ -17,7 +17,11 @@ services:
     env_file:
       - path: .env.development.local
         required: true
-    image: node
+    environment:
+      OPEN_BROWSER: false
+    image: node:20
+    stdin_open: true
+    tty: true
     labels:
       - 'app=bikehopper-ui-dev'
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     ports:
       - 9229:9229
       - 3000:3000
-    command: ['npm', 'start']
+    command: ['npm', 'start', '--', '--host']
     depends_on:
       bikehopper-ui-setup:
         condition: service_completed_successfully

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "scripts": {
     "start": "vite",
+    "start:docker": "docker compose up",
     "build": "vite build",
     "serve": "vite preview",
     "lint": "eslint --max-warnings 0 --report-unused-disable-directives src/**/*.{js,jsx,ts,tsx} && npx tsc",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig(() => {
       basicSsl(),
     ],
     server: {
-      open: true,
+      host: true,
       port: 3000,
       proxy: {
         '/api/v1': 'https://api-staging.bikehopper.org',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,6 @@ export default defineConfig(({ mode }) => {
       basicSsl(),
     ],
     server: {
-      host: true,
       port: 3000,
       open,
       proxy: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,13 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import eslint2 from 'vite-plugin-eslint2';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import babelPluginFormatjs from 'babel-plugin-formatjs';
 
-export default defineConfig(() => {
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const open = env.OPEN_BROWSER === 'false' ? false : true;
   return {
     build: {
       rollupOptions: {
@@ -41,6 +43,7 @@ export default defineConfig(() => {
     server: {
       host: true,
       port: 3000,
+      open,
       proxy: {
         '/api/v1': 'https://api-staging.bikehopper.org',
       },


### PR DESCRIPTION
To use the docker dev env you only need docker and git installed locally. git clone the the UI repo, cd into it, then run `docker compose up`. lastly open [https://localhost:3000/](https://localhost:3000/) in your browser. 

The vite "open" option that pops your browser open does not work in docker because of docker security model, the workarounds are ugly. If you still want a JS devX you can clone the repo and run `npm run start:dev` this just calls docker compose up but many JS dev, expect an `npm` based start up command. i think it is fine and we only use `npm` to call a script and i highly doubt the `npm` scripts API will change, so we don't really need to worry about what version of node/`npm` someone has installed. Since in theory all the node stuff happens in a container, which has its own node version specified, we could delete the .node-version file. ideally we only define a node version in one place in the project, right now there are few.