### PR TITLE
Transit alerts: omit colon if no body

### DIFF
--- a/src/components/ItineraryHeader.css
+++ b/src/components/ItineraryHeader.css
@@ -78,7 +78,7 @@
   font-weight: bold;
 }
 
-.ItineraryHeader_alertHeader::after {
+.ItineraryHeader_alertHeader__hasBody::after {
   content: ': ';
 }
 

--- a/src/components/ItineraryHeader.tsx
+++ b/src/components/ItineraryHeader.tsx
@@ -106,7 +106,12 @@ export default function ItineraryHeader({
               </Icon>
               {alertHeader && (
                 <>
-                  <span className="ItineraryHeader_alertHeader">
+                  <span
+                    className={classnames({
+                      ItineraryHeader_alertHeader: true,
+                      ItineraryHeader_alertHeader__hasBody: !!alertBody,
+                    })}
+                  >
                     {alertHeader}
                   </span>
                   <div />


### PR DESCRIPTION
This makes sure we don't show a colon unless there's both a header and a body. Addresses part of #258