### PR TITLE
2 taps for instructions

### DIFF
--- a/src/components/RoutesOverview.jsx
+++ b/src/components/RoutesOverview.jsx
@@ -12,6 +12,7 @@ import SelectionListItem from './SelectionListItem';
 import ArrowDown from 'iconoir/icons/arrow-down.svg?react';
 import ArrowUp from 'iconoir/icons/arrow-up.svg?react';
 import NavArrowRight from 'iconoir/icons/nav-arrow-right.svg?react';
+import ListIcon from 'iconoir/icons/list.svg?react';
 
 import './RoutesOverview.css';
 
@@ -88,7 +89,17 @@ export default function RoutesOverview({
                 )}
               </p>
             </div>
-            <p className="RoutesOverview_departArriveTime">
+            <p
+              className={classnames({
+                RoutesOverview_departArriveTime: true,
+                nothing: activeRoute === index,
+              })}
+            >
+              {activeRoute === index && (
+                <Icon className="relative top-0.5 pr-0.5">
+                  <ListIcon height="16" width="16" />
+                </Icon>
+              )}
               <FormattedMessage
                 defaultMessage="{depart}–{arrive}"
                 description="compact departure and arrival time"

--- a/src/features/routes.ts
+++ b/src/features/routes.ts
@@ -132,13 +132,10 @@ export function routesReducer(
       return produce(state, (draft) => {
         draft.activeRoute = action.index;
 
-        if (action.source === 'list') {
-          // If the route clicked was already active, toggle viewing details.
-          // Otherwise, always view the details.
-          draft.viewingDetails =
-            state.activeRoute !== action.index || !state.viewingDetails;
+        if (action.source === 'list' && state.activeRoute === action.index) {
+          // If the route clicked was already active, show details.
+          draft.viewingDetails = true;
         } else if (action.source === 'map') {
-          draft.viewingDetails = false;
           draft.viewingStep = null;
         }
       });


### PR DESCRIPTION
In my experience watching people use BikeHopper, when they click on an itinerary other than the first one, they usually just want to highlight it on the map, and don't want to go into the detailed instructions screen.

This change makes it so that the first tap on an unselected itinerary just highlights it, while tapping on an already selected itinerary still goes into the instructions.

To hint that step-by-step instructions are available, a new bullet-point list icon is shown on the selected itinerary.

Default state:

![Screen Shot 2024-08-21 at 17 35 13](https://github.com/user-attachments/assets/b997eeda-2612-404e-bacb-27b0662f606b)

After tapping once on second itinerary:

![Screen Shot 2024-08-21 at 17 35 30](https://github.com/user-attachments/assets/ecbb7676-e233-460d-b823-eef4f00878de)
