### PR TITLE
Update start/end input text to reflect geocoding

### DIFF
--- a/src/features/routeParams.ts
+++ b/src/features/routeParams.ts
@@ -95,6 +95,20 @@ export function routeParamsReducer(
         draft.start = action.start;
         draft.end = action.end;
         if (action.start && action.end) draft.editingLocation = null;
+
+        // Update text to reflect a geocoded location
+        if (
+          action.start?.source === LocationSourceType.Geocoded &&
+          action.start.fromInputText === state.startInputText
+        ) {
+          draft.startInputText = describePlace(action.start.point);
+        }
+        if (
+          action.end?.source === LocationSourceType.Geocoded &&
+          action.end.fromInputText === state.endInputText
+        ) {
+          draft.endInputText = describePlace(action.end.point);
+        }
       });
     case 'locations_swapped':
       return produce(state, (draft) => {


### PR DESCRIPTION
Purpose: Mitigate bad geocoding like in issue #230 where typing an address like "250 Howard Street" results in a generic result for just "Howard Street."

How it works today: If you click on a geocoded result from the dropdown, the input text gets replaced with a description of that geocoded result. But if you type something and hit Return, your typed text stays unchanged, giving no indication of what result was found.

What this commit changes: Typing something and hitting Return will also replace your input text with a description of the geocoded result.

Future work: Fix Photon not to return results at all if they fail to match part of what you typed (or flag such results as inexact). Get better address data into our geocoder.