### PR TITLE
Fix FormatJS extraction of .ts files

### DIFF
--- a/compiled-lang/en.json
+++ b/compiled-lang/en.json
@@ -467,6 +467,12 @@
       "value": "Current Location"
     }
   ],
+  "Fle6qD": [
+    {
+      "type": 0,
+      "value": "Unable to generate FIT file"
+    }
+  ],
   "Gm6D00": [
     {
       "type": 0,
@@ -1149,12 +1155,6 @@
     {
       "type": 0,
       "value": "west"
-    }
-  ],
-  "pFBkix": [
-    {
-      "type": 0,
-      "value": "Custom"
     }
   ],
   "qyWb6X": [

--- a/lang/en.json
+++ b/lang/en.json
@@ -135,6 +135,10 @@
     "defaultMessage": "Current Location",
     "description": "option that can be selected (or typed in) to get directions from or to the current location of the user, as determined by GPS"
   },
+  "Fle6qD": {
+    "defaultMessage": "Unable to generate FIT file",
+    "description": "error when we can't generate a FIT file (a file format used in a cycling computer)."
+  },
   "Gm6D00": {
     "defaultMessage": "Turn <dir>right</dir>{haveStreet, select, name { onto <name>{street}</name>} other {}}",
     "description": "instruction"
@@ -358,10 +362,6 @@
   "p04B0A": {
     "defaultMessage": "west",
     "description": "cardinal direction, used in a sentence like \"Head west\""
-  },
-  "pFBkix": {
-    "defaultMessage": "Custom",
-    "description": "description of a route start/end point that was selected on the map"
   },
   "qyWb6X": {
     "defaultMessage": "Connecting modes",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "lint": "eslint --max-warnings 0 --report-unused-disable-directives src/**/*.{js,jsx,ts,tsx} && npx tsc",
-    "extract": "formatjs extract 'src/**/*.{js,jsx}' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'",
+    "extract": "formatjs extract 'src/**/*.{ts,tsx,js,jsx}' --ignore 'src/**/*.d.ts' --out-file lang/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'",
     "compile": "formatjs compile",
     "prepare": "husky"
   },


### PR DESCRIPTION
We were not extracting strings from TypeScript files for translation. Note our sole, so far, .d.ts file breaks extraction; it seems FormatJS can't parse `declare module`.