### PR TITLE
Hide warning about querying layer not in map

### DIFF
--- a/src/components/BikeHopperMap.tsx
+++ b/src/components/BikeHopperMap.tsx
@@ -145,6 +145,7 @@ const BikeHopperMap = forwardRef(function _BikeHopperMap(
 
   const findFeaturesNear = useCallback(
     (point: MapLibrePoint) => {
+      if (!routes || routes.length === 0) return [];
       const map = mapRef.current;
       if (!map) return [];
       const southwest = point.sub(MAP_CLICK_FUDGE_VEC);
@@ -153,7 +154,7 @@ const BikeHopperMap = forwardRef(function _BikeHopperMap(
         layers: INTERACTIVE_LAYER_IDS,
       });
     },
-    [mapRef],
+    [mapRef, routes],
   );
 
   const handleMapClick = (evt: MapLayerMouseEvent) => {


### PR DESCRIPTION
The interactive layers we're querying such as inactiveLayer only exist when routes are displayed, and MapLibre was printing a warning in the console in dev mode about them not existing.

To fix, only query for features on those layers when routes are being displayed.