### PR TITLE
Lint: don't block dev when debugger statement added

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ export default [
       'no-unused-vars': ['warn', { args: 'none', caughtErrors: 'none' }],
       'react/prop-types': 'off',
       'react/jsx-key': 'warn',
+      'no-debugger': 'warn',
       'no-empty': ['warn', { allowEmptyCatch: true }],
       'no-constant-condition': 'warn',
       'no-unreachable': 'warn',


### PR DESCRIPTION
Having 'no-debugger' as an error means you're blocked from using the app in development when you place a debugger statement, which makes them unusable. Changing it to a warning will allow using them and make sure we remove them before commit.