### PR TITLE
Fix bug: no autocomplete result for exact string

### DIFF
--- a/src/components/SearchDropdown.tsx
+++ b/src/components/SearchDropdown.tsx
@@ -373,7 +373,8 @@ const _searchDropdownSelector = createSelector(
           ![thisId, otherId].includes(
             feat.properties.osm_type + feat.properties.osm_id,
           ) &&
-          ![thisLocationText, otherLocationText].includes(describePlace(feat)),
+          !(thisLocation && thisLocationText === describePlace(feat)) &&
+          !(otherLocation && otherLocationText === describePlace(feat)),
       )
       .slice(0, 8);
 


### PR DESCRIPTION
If you typed the exact, full string that an OSM point of interest renders as, it would not be shown (but any prefix of it worked fine).