### PR TITLE
Search: Link to retry geocoding

### DIFF
--- a/src/components/SearchDropdown.tsx
+++ b/src/components/SearchDropdown.tsx
@@ -1,12 +1,15 @@
 import classnames from 'classnames';
-import { cloneElement, useCallback } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { cloneElement } from 'react';
+import { useIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import MoonLoader from 'react-spinners/MoonLoader';
 import { createSelector } from 'reselect';
 import type { PhotonOsmHash } from '../lib/BikeHopperClient';
-import { removeRecentlyUsedLocation } from '../features/geocoding';
+import {
+  GeocodeFailureType,
+  removeRecentlyUsedLocation,
+} from '../features/geocoding';
 import type {
   OsmCacheItem,
   OsmId,
@@ -23,6 +26,7 @@ import describePlace from '../lib/describePlace';
 import { parsePossibleCoordsString, stringifyCoords } from '../lib/geometry';
 import Icon from './primitives/Icon';
 import PlaceIcon from './PlaceIcon';
+import SearchDropdownGeocodeError from './SearchDropdownGeocodeError';
 import SelectionList from './SelectionList';
 import SelectionListItem from './SelectionListItem';
 import type { Dispatch, RootState } from '../store';
@@ -52,18 +56,13 @@ export default function SearchDropdown({
       'option that can be selected (or typed in) to get directions from or ' +
       'to the current location of the user, as determined by GPS',
   });
-  const strong = useCallback(
-    (txt: React.ReactNode) => <strong>{txt}</strong>,
-    [],
-  );
-
   const {
     inputText,
     autocompletedText,
     features,
     showCurrentLocationOption,
     loading,
-    noResults, // we explicitly searched and found no results
+    noResultsReason, // we explicitly searched and found no results
     parsedCoords,
   }: {
     inputText: string;
@@ -71,7 +70,7 @@ export default function SearchDropdown({
     features: DropdownFeature[];
     showCurrentLocationOption: boolean;
     loading: boolean;
-    noResults: boolean;
+    noResultsReason: GeocodeFailureType | undefined;
     parsedCoords: [number, number] | null;
   } = useSelector(
     (state) =>
@@ -160,17 +159,15 @@ export default function SearchDropdown({
           />
         ))}
       </SelectionList>
-      {(loading || noResults) && (
+      {(loading || Boolean(noResultsReason)) && (
         <div className="relative inset-x-0 pt-4 pl-12 pointer-events-none">
           <MoonLoader size={30} loading={loading} />
-          {noResults && !parsedCoords && (
-            <span className="text-sm">
-              <FormattedMessage
-                defaultMessage="Nothing found for ''{inputText}''"
-                description="Message when no search results are found"
-                values={{ inputText, strong }}
-              />
-            </span>
+          {noResultsReason && !parsedCoords && (
+            <SearchDropdownGeocodeError
+              inputText={inputText}
+              failureType={noResultsReason}
+              startOrEnd={startOrEnd}
+            />
           )}
         </div>
       )}
@@ -248,13 +245,15 @@ const _searchDropdownSelector = createSelector(
     let cache = inputText && typeaheadCache['@' + inputText];
     let fallbackToGeocodedLocationSourceText = false;
     let loading = false;
-    let noResults = false;
+    let noResultsReason: GeocodeFailureType | undefined;
     if (!parsedCoords && (!cache || cache.status !== 'succeeded')) {
       if (inputText !== '' && (!cache || cache?.status === 'fetching')) {
         loading = true;
       }
       // TODO: should we distinguish b/t server error & no match?
-      if (cache && cache.status === 'failed') noResults = true;
+      if (cache && cache.status === 'failed') {
+        noResultsReason = cache.failureType;
+      }
 
       // If the location we're editing has a geocoded location already selected, display the
       // other options from the input text that was used to pick that.
@@ -384,7 +383,7 @@ const _searchDropdownSelector = createSelector(
       features: shownFeatures,
       showCurrentLocationOption,
       loading,
-      noResults,
+      noResultsReason,
       parsedCoords,
     };
   },

--- a/src/components/SearchDropdown.tsx
+++ b/src/components/SearchDropdown.tsx
@@ -250,7 +250,6 @@ const _searchDropdownSelector = createSelector(
       if (inputText !== '' && (!cache || cache?.status === 'fetching')) {
         loading = true;
       }
-      // TODO: should we distinguish b/t server error & no match?
       if (cache && cache.status === 'failed') {
         noResultsReason = cache.failureType;
       }

--- a/src/components/SearchDropdownGeocodeError.tsx
+++ b/src/components/SearchDropdownGeocodeError.tsx
@@ -1,0 +1,71 @@
+import { FormattedMessage } from 'react-intl';
+import {
+  GeocodeFailureType,
+  geocodeTypedLocation,
+} from '../features/geocoding';
+import type { Dispatch } from '../store';
+import BorderlessButton from './BorderlessButton';
+import { useDispatch } from 'react-redux';
+
+export default function SearchDropdownGeocodeError({
+  failureType,
+  inputText,
+  startOrEnd,
+}: {
+  failureType: GeocodeFailureType;
+  inputText: string;
+  startOrEnd: 'start' | 'end';
+}) {
+  const dispatch: Dispatch = useDispatch();
+
+  const handleRetryClick = () => {
+    dispatch(
+      geocodeTypedLocation(inputText, startOrEnd, {
+        fromTextAutocomplete: true,
+        isRetry: true,
+      }),
+    );
+  };
+
+  const retryLink = (
+    <BorderlessButton
+      onClick={handleRetryClick}
+      className="text-blue-500 underline inline pointer-events-auto"
+    >
+      <FormattedMessage
+        defaultMessage="Retry"
+        description="Button. Retries a failed action"
+      />
+    </BorderlessButton>
+  );
+
+  return (
+    <span className="text-sm">
+      {failureType === GeocodeFailureType.NO_POINTS_FOUND ? (
+        <FormattedMessage
+          defaultMessage="Nothing found for ''{inputText}''"
+          description="Message when no search results are found"
+          values={{ inputText }}
+        />
+      ) : failureType === GeocodeFailureType.NETWORK_ERROR ? (
+        <FormattedMessage
+          defaultMessage="Unable to connect to server. {retryLink}"
+          description={
+            'Error message with a link to retry. ' + 'The link text is "Retry".'
+          }
+          values={{ retryLink }}
+        />
+      ) : (
+        <FormattedMessage
+          defaultMessage="Server error. {retryLink}"
+          description={
+            'Error message with a link to retry. ' +
+            'The link text is "Retry". The error means there is probably ' +
+            'a problem on the server.'
+          }
+          values={{ retryLink }}
+        />
+      )}
+    </span>
+  );
+}

--- a/src/features/geocoding.ts
+++ b/src/features/geocoding.ts
@@ -183,7 +183,13 @@ type GeocodeFailedAction = Action<'geocode_failed'> & {
 export function geocodeTypedLocation(
   text: string,
   key: string,
-  { fromTextAutocomplete }: { fromTextAutocomplete?: boolean } = {},
+  {
+    fromTextAutocomplete,
+    isRetry,
+  }: {
+    fromTextAutocomplete?: boolean;
+    isRetry?: boolean; // Initiated by user clicking Retry in dropdown
+  } = {},
 ): BikeHopperThunkAction {
   return async function geocodeTypedLocationThunk(dispatch, getState) {
     text = text.trim();
@@ -191,7 +197,7 @@ export function geocodeTypedLocation(
 
     _LOCATION_TYPED_ACTION_LAST_TEXT_FOR_KEY[key] = text;
 
-    if (fromTextAutocomplete) {
+    if (fromTextAutocomplete && !isRetry) {
       if (import.meta.env.VITE_USE_PUBLIC_NOMINATIM) {
         // Public Nominatim is for development / demo only, and to comply with
         // the API guidelines, we must limit requests to 1/sec and not use it


### PR DESCRIPTION
Distinguishes between "There are no results for what you typed in"...

![Screenshot from 2025-01-14 21-21-50](https://github.com/user-attachments/assets/36e49bef-71ac-45ee-b8e4-6404e5946d23)

...and "Your connection is down" (or "The server errored," not shown):

![Screenshot from 2025-01-14 21-22-21](https://github.com/user-attachments/assets/714c868e-15fa-4a69-9b5b-5872b199821e)

In that case you can retry. Fixes #409