### PR TITLE
Fix missing controls on mobile

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -110,10 +110,13 @@ function App(props: Props) {
   );
 
   const [isMapLoaded, setIsMapLoaded] = useState(false);
-  const handleMapLoad = useCallback((evt: MapEvent) => {
-    setIsMapLoaded(true);
-    mapRefs.handleMapLoad();
-  }, []);
+  const handleMapLoad = useCallback(
+    (evt: MapEvent) => {
+      setIsMapLoaded(true);
+      mapRefs.handleMapLoad();
+    },
+    [mapRefs],
+  );
 
   return (
     <IntlProvider

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { FocusEvent } from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import type { MessageFormatElement } from 'react-intl';
+import type { MapEvent } from 'react-map-gl/maplibre';
 import type { OnErrorFn } from '@formatjs/intl';
 import { Transition } from '@headlessui/react';
 import { Provider as ToastProvider } from '@radix-ui/react-toast';
@@ -108,6 +109,12 @@ function App(props: Props) {
     [],
   );
 
+  const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const handleMapLoad = useCallback((evt: MapEvent) => {
+    setIsMapLoaded(true);
+    mapRefs.handleMapLoad();
+  }, []);
+
   return (
     <IntlProvider
       messages={props.messages}
@@ -118,7 +125,7 @@ function App(props: Props) {
       <InPortal node={mapPortal}>
         <BikeHopperMap
           ref={mapRefs.mapRef}
-          onMapLoad={mapRefs.handleMapLoad}
+          onMapLoad={handleMapLoad}
           overlayRef={mapRefs.mapOverlayRef}
           hidden={isMobile && isEditingLocations}
           isMobile={isMobile}
@@ -134,6 +141,7 @@ function App(props: Props) {
               hideMap={isEditingLocations}
               infoBox={infoBox}
               loading={loading}
+              isMapLoaded={isMapLoaded}
             />
           ) : (
             <DesktopMapLayout

--- a/src/components/BikeHopperMap.tsx
+++ b/src/components/BikeHopperMap.tsx
@@ -83,7 +83,7 @@ import Color from 'color';
 const _isTouch = 'ontouchstart' in window;
 
 type Props = {
-  onMapLoad?: () => void;
+  onMapLoad?: (evt: MapEvent) => void;
   overlayRef: RefObject<HTMLDivElement | null>;
   hidden: boolean;
   isMobile: boolean;
@@ -330,7 +330,7 @@ const BikeHopperMap = forwardRef(function BikeHopperMapInternal(
   };
 
   const handleMapLoad = async (event: MapEvent) => {
-    if (props.onMapLoad) props.onMapLoad();
+    if (props.onMapLoad) props.onMapLoad(event);
     dispatch(mapLoaded());
     const map = event.target;
 

--- a/src/components/MobileMapLayout.tsx
+++ b/src/components/MobileMapLayout.tsx
@@ -17,7 +17,6 @@ import * as VisualViewportTracker from '../lib/VisualViewportTracker';
 
 import './MobileMapLayout.css';
 import { MapRefs } from '../hooks/useMapRefs';
-import useScreenDims from '../hooks/useScreenDims';
 
 /*
  * This component renders the map, plus the top bar and bottom drawer.
@@ -58,6 +57,7 @@ type Props = {
   hideMap: boolean;
   header: React.ReactNode;
   infoBox?: React.ReactNode;
+  isMapLoaded: boolean;
   loading: boolean;
 };
 
@@ -69,6 +69,7 @@ type TouchEventOptions = {
 function MobileMapLayout({
   mapPortal,
   infoBox,
+  isMapLoaded,
   header,
   hideMap,
   mapRefs,
@@ -82,8 +83,6 @@ function MobileMapLayout({
     mapControlTopRightRef,
     mapOverlayRef,
   } = mapRefs;
-
-  const { isMobile } = useScreenDims();
 
   const columnRef = useRef<HTMLDivElement | null>(null);
 
@@ -262,10 +261,9 @@ function MobileMapLayout({
   ]);
 
   useEffect(() => {
-    if (isMobile) {
-      window.requestAnimationFrame(updateMapBottomControls);
-      updateMapTopControls();
-    }
+    if (!isMapLoaded) return;
+    window.requestAnimationFrame(updateMapBottomControls);
+    updateMapTopControls();
 
     const mapControlTopLeft = mapControlTopLeftRef.current;
     const mapControlTopRight = mapControlTopRightRef.current;
@@ -287,7 +285,7 @@ function MobileMapLayout({
       }
     };
   }, [
-    isMobile,
+    isMapLoaded,
     mapControlTopLeftRef,
     mapControlTopRightRef,
     mapControlBottomLeftRef,


### PR DESCRIPTION
Broken by desktop layout (#398): The controls were formerly updated upon a map load event, but that PR removed this.

Fixes #425