### PR TITLE
Build: improve chunking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,10 +13,16 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         output: {
           manualChunks: {
+            react: [
+              'react',
+              'react/jsx-runtime',
+              'react-dom/client',
+              'react-redux',
+              'react-intl',
+            ],
             'maplibre-gl': ['maplibre-gl'],
             'react-map-gl': ['react-map-gl/maplibre'],
-            react: ['react', 'react-dom/client', 'react-redux', 'react-intl'],
-            '@nivo': ['@nivo/line'],
+            '@nivo': ['@nivo/line', '@nivo/axes', '@nivo/scales'],
           },
         },
       },


### PR DESCRIPTION
1. List React before React-Map-GL so React core doesn't end up in the React-Map-GL bundle

2. Include react/jsx-runtime in the React bundle so it doesn't end up in the Nivo bundle

3. Include other Nivo packages in Nivo bundle

There are still some needless dependencies, I'm not sure why. The getFitBlob bundle imports the React-Map-GL and Nivo bundles for no apparent reason, not importing anything from them, as though it is running them for side effects.