### PR TITLE
Use Bay Area Time for Time Picker

### DIFF
--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -144,10 +144,12 @@ export default function Itinerary({
               description="start and end time for a trip"
               values={{
                 startTime: intl.formatTime(startTime, {
+                  timeZone: 'America/Los_Angeles',
                   hour: 'numeric',
                   minute: 'numeric',
                 }),
                 endTime: intl.formatTime(endTime, {
+                  timeZone: 'America/Los_Angeles',
                   hour: 'numeric',
                   minute: 'numeric',
                 }),

--- a/src/components/RoutesOverview.tsx
+++ b/src/components/RoutesOverview.tsx
@@ -148,12 +148,17 @@ export default function RoutesOverview({
                 description="compact departure and arrival time"
                 values={{
                   depart: intl.formatTime(route.legs[0].departure_time, {
+                    timeZone: 'America/Los_Angeles',
                     hour: 'numeric',
                     minute: 'numeric',
                   }),
                   arrive: intl.formatTime(
                     route.legs[route.legs.length - 1].arrival_time,
-                    { hour: 'numeric', minute: 'numeric' },
+                    {
+                      timeZone: 'America/Los_Angeles',
+                      hour: 'numeric',
+                      minute: 'numeric',
+                    },
                   ),
                 }}
               />

--- a/src/lib/BikeHopperClient.ts
+++ b/src/lib/BikeHopperClient.ts
@@ -46,28 +46,28 @@ export async function fetchRegionConfig(): Promise<RegionConfig> {
 // See if there is a difference
 function timeStampToLocalTime(timeStamp: number) {
   const sysDate = new Date();
-  const sysMinutes = sysDate.getHours() * 60 + sysDate.getMinutes();
+  const sysSecs =
+    3600 * sysDate.getHours() +
+    60 * sysDate.getMinutes() +
+    sysDate.getSeconds();
 
   // you need more than hours - you need minutes -> 30/45 minute timezones
   const pst_formatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Los_Angeles',
     hour: '2-digit',
     minute: '2-digit',
+    second: '2-digit',
     hour12: false,
   });
 
   const parts = pst_formatter.formatToParts(sysDate);
-  const getPart = (type: string) => parts.find((p) => p.type === type)?.value;
+  const getPart = (type: string) =>
+    parseInt(parts.find((p) => p.type === type)!.value);
 
-  const pstMinutes =
-    parseInt(getPart('hour')!) * 60 + parseInt(getPart('minute')!);
+  const localSecs =
+    3600 * getPart('hour') + 60 * getPart('minute') + getPart('second');
 
-  if (pstMinutes === sysMinutes) {
-    return timeStamp;
-  }
-
-  // should this be more granular?
-  const timeDiffMS = 60 * 1000 * (sysMinutes - pstMinutes);
+  const timeDiffMS = 1000 * (sysSecs - localSecs);
 
   return timeStamp + timeDiffMS;
 }

--- a/src/lib/BikeHopperClient.ts
+++ b/src/lib/BikeHopperClient.ts
@@ -105,8 +105,6 @@ export async function fetchRoute({
     'pt.arrive_by': String(arriveBy),
   });
 
-  console.log(new Date(earliestDepartureLocal));
-
   for (const detail of details || []) params.append('details', detail);
   for (const routeType of blockRouteTypes || [])
     params.append('pt.block_route_types', String(routeType));

--- a/src/lib/BikeHopperClient.ts
+++ b/src/lib/BikeHopperClient.ts
@@ -40,24 +40,12 @@ export async function fetchRegionConfig(): Promise<RegionConfig> {
 }
 
 function timeStampToLocalTime(timeStamp: number) {
-  const sysDate = new Date();
-  const sysOffset = sysDate.getTimezoneOffset();
-
-  const pst_formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Los_Angeles',
-    timeZoneName: 'short',
-    hour12: false,
-  });
-
-  const parts = pst_formatter.formatToParts(sysDate);
-  const getPart = (type: string) => parts.find((p) => p.type === type)!.value;
-
-  const timezone = getPart('timeZoneName');
-  const localOffset = timezone === 'PST' ? 8 * 60 : 7 * 60;
-
-  const timeDiffMS = 60 * 1000 * (localOffset - sysOffset);
-
-  return timeStamp + timeDiffMS;
+  const serverTime = DateTime.fromMillis(timeStamp).setZone(
+    'America/Los_Angeles',
+    { keepLocalTime: true },
+  );
+  const clientTime = serverTime.toLocal().toMillis();
+  return clientTime;
 }
 
 type GtfsRouteType = number;

--- a/src/lib/BikeHopperClient.ts
+++ b/src/lib/BikeHopperClient.ts
@@ -39,35 +39,23 @@ export async function fetchRegionConfig(): Promise<RegionConfig> {
   return RegionConfigSchema.parse(await result.json());
 }
 
-// in when I say a time -> i ACTUALLY mean a time 3hrs in the FUTURE
-// find the time difference - e.g. 3 hours -> 3 hours of milis
-// take the date.now(), format
-// take date.now() - format to LA time
-// See if there is a difference
 function timeStampToLocalTime(timeStamp: number) {
   const sysDate = new Date();
-  const sysSecs =
-    3600 * sysDate.getHours() +
-    60 * sysDate.getMinutes() +
-    sysDate.getSeconds();
+  const sysOffset = sysDate.getTimezoneOffset();
 
-  // you need more than hours - you need minutes -> 30/45 minute timezones
   const pst_formatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Los_Angeles',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
+    timeZoneName: 'short',
     hour12: false,
   });
 
   const parts = pst_formatter.formatToParts(sysDate);
-  const getPart = (type: string) =>
-    parseInt(parts.find((p) => p.type === type)!.value);
+  const getPart = (type: string) => parts.find((p) => p.type === type)!.value;
 
-  const localSecs =
-    3600 * getPart('hour') + 60 * getPart('minute') + getPart('second');
+  const timezone = getPart('timeZoneName');
+  const localOffset = timezone === 'PST' ? 8 * 60 : 7 * 60;
 
-  const timeDiffMS = 1000 * (sysSecs - localSecs);
+  const timeDiffMS = 60 * 1000 * (localOffset - sysOffset);
 
   return timeStamp + timeDiffMS;
 }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -4,7 +4,9 @@ import type { IntlShape } from 'react-intl';
 // TODO localize all of these
 
 export function formatTime(jsDate: Date) {
-  return DateTime.fromJSDate(jsDate).toLocaleString(DateTime.TIME_SIMPLE);
+  return DateTime.fromJSDate(jsDate)
+    .setZone('America/Los_Angeles')
+    .toLocaleString(DateTime.TIME_SIMPLE);
 }
 
 export function formatInterval(milliseconds: number) {


### PR DESCRIPTION
Fixes #125 

**Motivation:** 
- When browsing in another TZ, BH will interpret the value "Depart At" field as your system time, instead of SF local time
- As per [this issue comment](https://github.com/bikehopper/bikehopper-ui/issues/125#issuecomment-1114124135):
   - in route results, all times should be displayed in Pacific Time
   - "depart now" should mean now
    - any specific time input as "depart at" or "arrive by" should be interpreted as Pacific Time

**Description of Changes:**
- Add timezone info to all components displaying departure/arrival time
- helper function to convert to local time
   - grabs the offset (in minutes) of system time from UTC
   -  calculates timezone offset of the current time in the  "America/Los_Angeles" locale
   - compute the diff between the system time and pacific time in milliseconds
   -  return timestamp + timediff


**Testing**

The following tests are not comprehensive (was unsure how detailed they have to be).
Tests are being conducted from the EDT TZ which is 3 hours ahead of PDT

Test route: 1900 Broadway, 1900 Broadway, Oakland, 94612 ->  Market Street (1100 Block), Market Street, San Francisco, 94102

Test case results were compared w/ [BART planner results](https://www.bart.gov/planner)

**TC 1: Depart now (4:30PM EDT) (05/27)  - assert departure/arrival times are in local time:**
 - old behaviour:  departure and arrival times are in **system TZ** -> correct route shown 
 - new behaviour: departure and arrival times are in **local TZ** -> correct route shown
     
**TC2 : Depart at 1am (05/28) - assert route uses 800 bus**
    - old behaviour: Shows yellow line bc 1am EDT == 10pm PDT
    - new behaviour: Shows 800 bus (correctly interpreting departure time as local)
    
**TC3: Arrive by 8am (05/28) - assert route shows yellow line**
 - old behaviour: Shows night bus route bc. 8am EDT == 5am PDT
  - new behaviour: Shows yellow line (correctly interpreting arrival time as local)
     
**TC4: Itinerary Times are Consistent**
- all times displayed throughout itinerary show local time

  
| TC | Old | New |
| --- | --- | --- |
| 1 | ![image](https://github.com/user-attachments/assets/b4dc7b5d-64bb-4b41-a0df-1e510c02d512) | ![image](https://github.com/user-attachments/assets/be8f7f78-1808-49ae-82b8-eeddbbcd9414) |
| 2 | ![image](https://github.com/user-attachments/assets/615c31cf-9af6-4591-8e3d-719a0852be9f)| ![image](https://github.com/user-attachments/assets/c8c5b58a-2704-4bb5-9298-1cd9d3491981) |
| 3 |  ![image](https://github.com/user-attachments/assets/06e5db9d-2d39-493a-9b78-c3804a7f9c06)| ![image](https://github.com/user-attachments/assets/d1ce749c-e45f-43f8-a36b-aacb3ae588b5) |

**Additonal notes**
First 800 bus route : 1:02 am -> 1:47am
Last 800 bus route:  4:32am -> 5:20am
