### PR TITLE
Deps cleanup: Remove @eslint/compat

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-import { fixupPluginRules } from '@eslint/compat';
 import formatjsPlugin from 'eslint-plugin-formatjs';
 import globals from 'globals';
 import js from '@eslint/js';
@@ -12,6 +11,7 @@ export default [
   js.configs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat['jsx-runtime'],
+  reactHooksPlugin.configs['recommended-latest'],
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: {
@@ -31,13 +31,9 @@ export default [
     plugins: {
       formatjs: formatjsPlugin,
       react: reactPlugin,
-      // Workaround til react-hooks plugin supports ESLint 9:
-      // https://github.com/facebook/react/issues/28313
-      'react-hooks': fixupPluginRules(reactHooksPlugin),
       'react-refresh': reactRefreshPlugin,
     },
     rules: {
-      ...reactHooksPlugin.configs.recommended.rules,
       'react/jsx-no-target-blank': 'off',
       'formatjs/enforce-default-message': 'error',
       'formatjs/enforce-description': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "zod-geojson": "^0.0.3"
       },
       "devDependencies": {
-        "@eslint/compat": "^1.2.3",
         "@eslint/js": "^9.15.0",
         "@formatjs/cli": "^6.2.9",
         "@maplibre/maplibre-gl-style-spec": "^19.3.3",
@@ -76,7 +75,7 @@
         "eslint": "^9.15.0",
         "eslint-plugin-formatjs": "^5.2.5",
         "eslint-plugin-react": "^7.34.1",
-        "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.6",
         "globals": "^16.0.0",
         "husky": "^9.0.11",
@@ -898,24 +897,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.9.tgz",
-      "integrity": "sha512-gCdSY54n7k+driCadyMNv8JSPzYLeDVM/ikZRtvtROBpRdFSkS8W9A82MqsaY7lZuwL0wiapgD0NT1xT0hyJsA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": "^9.10.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     ]
   },
   "devDependencies": {
-    "@eslint/compat": "^1.2.3",
     "@eslint/js": "^9.15.0",
     "@formatjs/cli": "^6.2.9",
     "@maplibre/maplibre-gl-style-spec": "^19.3.3",
@@ -90,7 +89,7 @@
     "eslint": "^9.15.0",
     "eslint-plugin-formatjs": "^5.2.5",
     "eslint-plugin-react": "^7.34.1",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.6",
     "globals": "^16.0.0",
     "husky": "^9.0.11",


### PR DESCRIPTION
React-hooks-plugin now supports flat config without this adapter