### PR TITLE
Fix centered text in SelectionListItem

### DIFF
--- a/src/components/SelectionListItem.css
+++ b/src/components/SelectionListItem.css
@@ -12,6 +12,7 @@
 .SelectionListItem_button {
   padding: 8px 24px;
   flex-grow: 1;
+  text-align: left;
 }
 
 .SelectionListItem_button__removable {


### PR DESCRIPTION
The Tailwind preflight handles most of the button reset but not text-align: left, leading to this glitch:

![image](https://github.com/user-attachments/assets/250af990-6fc3-476f-a8ea-a29c1ba1eae2)
