### PR TITLE
Fix "Transit options may be missing" message

### DIFF
--- a/src/components/RoutesOverview.tsx
+++ b/src/components/RoutesOverview.tsx
@@ -65,7 +65,11 @@ export default function RoutesOverview({
 
   return (
     <div className="flex flex-col">
-      {outOfAreaMsg && <div className="border-gray-300">{outOfAreaMsg}</div>}
+      {outOfAreaMsg && (
+        <div className="border-b-[#c4c4c4] py-2 px-6 text-sm">
+          {outOfAreaMsg}
+        </div>
+      )}
       <SelectionList className="rounded-t-large">
         {routes.map((route, index) => (
           <SelectionListItem


### PR DESCRIPTION
The styling was wrong. No padding and huge.

**Before**

<img width="376" height="668" alt="Screen Shot 2026-03-09 at 00 19 35" src="https://github.com/user-attachments/assets/b3de3b36-3f7c-4d23-8c19-f7c6a078b349" />

**After**

<img width="376" height="668" alt="Screen Shot 2026-03-09 at 00 23 11" src="https://github.com/user-attachments/assets/5f7ecbf0-f55a-4cb2-b6d1-d234cff3da0e" />